### PR TITLE
Fix Windows build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+ifeq ($(OS),Windows_NT)
+	SHELL=cmd
+endif
+
 # Get the directory of the current Makefile
 MAKEFILE_PATH := $(dir $(realpath $(firstword $(MAKEFILE_LIST))))
 REVA_PYTHON_PATH := $(MAKEFILE_PATH)/reverse-engineering-assistant/reverse_engineering_assistant

--- a/ghidra-assistant/build.gradle
+++ b/ghidra-assistant/build.gradle
@@ -51,6 +51,9 @@ else {
 }
 //----------------------END "DO NOT MODIFY" SECTION-------------------------------
 
+compileJava.options.encoding = "UTF-8"
+compileTestJava.options.encoding = "UTF-8"
+
 repositories {
 	// Declare dependency repositories here.  This is not needed if dependencies are manually
 	// dropped into the lib/ directory.


### PR DESCRIPTION
Couple of small patches.
- Specify cmd as Makefile shell on Windows (Make on Windows will default to sh/bash when it's also available, which we don't want)
- set UTF-8 Java source encoding