### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish-ghidra.yml
+++ b/.github/workflows/publish-ghidra.yml
@@ -6,8 +6,9 @@ on:
   workflow_dispatch:
 jobs:
   build:
+    permissions:
+      contents: read
     strategy:
-      matrix:
         # The extension is Java only, so it should work on all platforms
         # but there have been issues with building on Windows (#73, #72)
         # that are related to protobufs, so we will build on all platforms

--- a/.github/workflows/publish-ghidra.yml
+++ b/.github/workflows/publish-ghidra.yml
@@ -9,6 +9,7 @@ jobs:
     permissions:
       contents: read
     strategy:
+      matrix:
         # The extension is Java only, so it should work on all platforms
         # but there have been issues with building on Windows (#73, #72)
         # that are related to protobufs, so we will build on all platforms


### PR DESCRIPTION
Potential fix for [https://github.com/cyberkaida/reverse-engineering-assistant/security/code-scanning/5](https://github.com/cyberkaida/reverse-engineering-assistant/security/code-scanning/5)

To fix the issue, we need to add a `permissions` block to the `build` job in the workflow file. Since the `build` job does not require write permissions, we will set `contents: read` as the minimal permission required. This change ensures that the `GITHUB_TOKEN` used in the job has restricted access, adhering to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
