### PR TITLE
Potential fix for code scanning alert no. 15: Reference equality test on strings

### DIFF
--- a/src/main/java/reva/server/McpServerManager.java
+++ b/src/main/java/reva/server/McpServerManager.java
@@ -276,7 +276,7 @@ public class McpServerManager {
      * @return true if the server is ready
      */
     public boolean isServerReady() {
-        return httpServer.getState() == org.eclipse.jetty.server.Server.STARTED;
+        return httpServer.getState().equals(org.eclipse.jetty.server.Server.STARTED);
     }
 
     /**


### PR DESCRIPTION
Potential fix for [https://github.com/cyberkaida/reverse-engineering-assistant/security/code-scanning/15](https://github.com/cyberkaida/reverse-engineering-assistant/security/code-scanning/15)

To fix the issue, replace the `==` operator with the `.equals()` method for comparing the `String` values. This ensures that the comparison checks the content of the strings rather than their reference identity. Specifically, update the condition on line 279 to use `httpServer.getState().equals(org.eclipse.jetty.server.Server.STARTED)`.

No additional imports, methods, or definitions are required to implement this fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
