### PR TITLE
Add decompiler search limit, add references and context

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,23 +1,13 @@
-This is a Ghidra extensions for Ghidra 11.3 and later called "ReVa", the Reverse Engineering Assistant.
-
-The extension provides a Model Context Protocol (MCP) server for Ghidra. The server is implemented in Java and uses the MCP Java SDK.
-
-Remember the life cycle of Ghidra extensions and always reference the Ghidra documentation for the latest information.
-We need the core MCP server to be static so it is tied to the lifetime of Ghidra.
-Some program specific data can be exposed as resources and tied to the lifetime of the program.
-Make sure that tools are available in the static context and not tied to a single program lifetime,
-they should take the program path as a parameter when needed.
-
-Remember that MCP is in development, so make sure to check the MCP documentation for the latest information.
+- This is a Ghidra extensions for Ghidra 11.3 and later called "ReVa", the Reverse Engineering Assistant.
+- The extension provides a Model Context Protocol (MCP) server for Ghidra. The server is implemented in Java and uses the MCP Java SDK.
+- Remember that MCP is in development, so make sure to check the MCP documentation for the latest information.
 
 Some good resources include:
 - [The MCP Java SDK](https://modelcontextprotocol.io/sdk/java/mcp-server)
 - [Ghidra on GitHub](https://github.com/NationalSecurityAgency/ghidra)
 
-If you want to find a Ghidra API, start from the FlatProgramAPI or the ProgramPlugin API in the Ghidra repo. Use the GitHub tools to search for Ghidra documentation.
-
-We don't use a gradle wrapper, so just run `gradle` in the root directory to build the project. We do have the Java tools installed in VSCode so you can just check for errors with VSCode instead.
-
-When writing tests, use the Ghidra test framework. The tests are in the `src/test` directory. It is easy to run them with `gradle test --info`.
-
-We target Ghidra 11.3 and later. Note we should use Java 21.
+- If you want to find a Ghidra API, start from the FlatProgramAPI or the ProgramPlugin API in the Ghidra repo. Use the GitHub tools to search for Ghidra documentation.
+- We don't use a gradle wrapper, so just run `gradle` in the root directory to build the project. We do have the Java tools installed in VSCode so you can just check for errors with VSCode instead.
+- When writing tests, use the Ghidra test framework. The tests are in the `src/test` directory. It is easy to run them with `gradle test --info` and the integration tests with `gradle integrationTest --info`.
+- You can use standard gradle test filtering to run specific tests with both of the test targets.
+- We target Ghidra 11.3 and later. Note we should use Java 21.

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -5,6 +5,12 @@
 - Use `Function.getParameters()` and `Function.getAllVariables()` to validate variable changes
 - Use `DataType.isEquivalent()` to compare datatypes before/after changes
 
+# Address Formatting
+- **ALWAYS use `AddressUtil.formatAddress(address)`** for consistent address formatting in JSON output
+- This ensures all addresses have the "0x" prefix format consistently across all ReVa tools
+- Import: `import reva.util.AddressUtil;`
+- Format: `AddressUtil.formatAddress(address)` returns `"0x" + address.toString()`
+
 # Decompiler Tool Implementation Pattern
 ## Adding New Tools to DecompilerToolProvider.java
 1. Create `register[ToolName]Tool()` method following existing patterns

--- a/src/main/java/reva/plugin/ConfigManager.java
+++ b/src/main/java/reva/plugin/ConfigManager.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package reva.util;
+package reva.plugin;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -34,11 +34,13 @@ public class ConfigManager {
     public static final String SERVER_PORT = "Server Port";
     public static final String SERVER_ENABLED = "Server Enabled";
     public static final String DEBUG_MODE = "Debug Mode";
+    public static final String MAX_DECOMPILER_SEARCH_FUNCTIONS = "Max Decompiler Search Functions";
 
     // Default values
     private static final int DEFAULT_PORT = 8080;
     private static final boolean DEFAULT_SERVER_ENABLED = true;
     private static final boolean DEFAULT_DEBUG_MODE = false;
+    private static final int DEFAULT_MAX_DECOMPILER_SEARCH_FUNCTIONS = 1000;
 
     private final PluginTool tool;
     private final Map<String, Object> cachedOptions = new HashMap<>();
@@ -65,11 +67,15 @@ public class ConfigManager {
             "Whether the ReVa MCP server is enabled");
         options.registerOption(DEBUG_MODE, DEFAULT_DEBUG_MODE, null,
             "Whether debug mode is enabled");
+        options.registerOption(MAX_DECOMPILER_SEARCH_FUNCTIONS, DEFAULT_MAX_DECOMPILER_SEARCH_FUNCTIONS, null,
+            "Maximum number of functions before discouraging decompiler search");
 
         // Cache the options
         cachedOptions.put(SERVER_PORT, options.getInt(SERVER_PORT, DEFAULT_PORT));
         cachedOptions.put(SERVER_ENABLED, options.getBoolean(SERVER_ENABLED, DEFAULT_SERVER_ENABLED));
         cachedOptions.put(DEBUG_MODE, options.getBoolean(DEBUG_MODE, DEFAULT_DEBUG_MODE));
+        cachedOptions.put(MAX_DECOMPILER_SEARCH_FUNCTIONS,
+            options.getInt(MAX_DECOMPILER_SEARCH_FUNCTIONS, DEFAULT_MAX_DECOMPILER_SEARCH_FUNCTIONS));
 
         Msg.debug(this, "Loaded ReVa configuration settings");
     }
@@ -143,5 +149,21 @@ public class ConfigManager {
      */
     public void setDebugMode(boolean enabled) {
         saveOption(SERVER_OPTIONS, DEBUG_MODE, enabled);
+    }
+
+    /**
+     * Get the maximum number of functions to search in the decompiler
+     * @return The configured maximum number of functions
+     */
+    public int getMaxDecompilerSearchFunctions() {
+        return (Integer) cachedOptions.getOrDefault(MAX_DECOMPILER_SEARCH_FUNCTIONS, DEFAULT_MAX_DECOMPILER_SEARCH_FUNCTIONS);
+    }
+
+    /**
+     * Set the maximum number of functions to search in the decompiler
+     * @param maxFunctions The maximum number of functions
+     */
+    public void setMaxDecompilerSearchFunctions(int maxFunctions) {
+        saveOption(SERVER_OPTIONS, MAX_DECOMPILER_SEARCH_FUNCTIONS, maxFunctions);
     }
 }

--- a/src/main/java/reva/server/McpServerManager.java
+++ b/src/main/java/reva/server/McpServerManager.java
@@ -37,7 +37,7 @@ import io.modelcontextprotocol.server.McpSyncServer;
 import io.modelcontextprotocol.server.transport.HttpServletSseServerTransportProvider;
 import io.modelcontextprotocol.spec.McpError;
 import io.modelcontextprotocol.spec.McpSchema;
-
+import reva.plugin.ConfigManager;
 import reva.resources.ResourceProvider;
 import reva.resources.impl.ProgramListResource;
 import reva.services.RevaMcpService;
@@ -54,7 +54,6 @@ import reva.tools.symbols.SymbolToolProvider;
 import reva.tools.xrefs.CrossReferencesToolProvider;
 import reva.tools.comments.CommentToolProvider;
 import reva.tools.bookmarks.BookmarkToolProvider;
-import reva.util.ConfigManager;
 import reva.util.RevaInternalServiceRegistry;
 
 /**

--- a/src/main/java/reva/tools/decompiler/DecompilerToolProvider.java
+++ b/src/main/java/reva/tools/decompiler/DecompilerToolProvider.java
@@ -820,6 +820,15 @@ public class DecompilerToolProvider extends AbstractToolProvider {
                 result.put("limit", limit);
             }
 
+            // Include incoming references at the top level if requested
+            if (includeIncomingReferences) {
+                List<Map<String, Object>> incomingRefs = DecompilationContextUtil
+                    .getEnhancedIncomingReferences(program, function, includeReferenceContext);
+                if (!incomingRefs.isEmpty()) {
+                    result.put("incomingReferences", incomingRefs);
+                }
+            }
+
             if (includeDisassembly) {
                 // Create synchronized content with assembly mapping
                 List<Map<String, Object>> syncedLines = new ArrayList<>();
@@ -846,15 +855,6 @@ public class DecompilerToolProvider extends AbstractToolProvider {
                         }
                     }
 
-                    // Include incoming references if requested and this is the first line of the function
-                    if (includeIncomingReferences && lineNumber == 1) {
-                        List<Map<String, Object>> incomingRefs = DecompilationContextUtil
-                            .getEnhancedIncomingReferences(program, function, includeReferenceContext);
-                        if (!incomingRefs.isEmpty()) {
-                            lineInfo.put("incomingReferences", incomingRefs);
-                        }
-                    }
-
                     syncedLines.add(lineInfo);
                 }
 
@@ -873,15 +873,6 @@ public class DecompilerToolProvider extends AbstractToolProvider {
                     List<Map<String, Object>> functionComments = getAllCommentsInFunction(program, function);
                     if (!functionComments.isEmpty()) {
                         result.put("comments", functionComments);
-                    }
-                }
-
-                // Include incoming references if requested
-                if (includeIncomingReferences) {
-                    List<Map<String, Object>> incomingRefs = DecompilationContextUtil
-                        .getEnhancedIncomingReferences(program, function, includeReferenceContext);
-                    if (!incomingRefs.isEmpty()) {
-                        result.put("incomingReferences", incomingRefs);
                     }
                 }
             }

--- a/src/main/java/reva/util/AddressUtil.java
+++ b/src/main/java/reva/util/AddressUtil.java
@@ -34,7 +34,7 @@ public class AddressUtil {
     /**
      * Format an address for JSON output with consistent "0x" prefix.
      * This is the standard format used across all ReVa tool providers.
-     * 
+     *
      * @param address The Ghidra address to format
      * @return A hex string representation with "0x" prefix
      */
@@ -42,13 +42,19 @@ public class AddressUtil {
         if (address == null) {
             return null;
         }
-        return "0x" + address.toString();
+        // Ensure we have an actual Address object and format it properly
+        if (!(address instanceof Address)) {
+            throw new IllegalArgumentException("Expected Address object, got: " + address.getClass().getName());
+        }
+
+        // address with a 0x prefix.
+        return address.toString("0x");
     }
 
     /**
      * Parse an address string that may or may not have a "0x" prefix.
      * This handles user input that might come in either format.
-     * 
+     *
      * @param program The Ghidra program to get the address space from
      * @param addressString The address string to parse (with or without "0x")
      * @return The parsed Address object, or null if parsing fails
@@ -74,7 +80,7 @@ public class AddressUtil {
 
     /**
      * Check if an address string is valid (parseable).
-     * 
+     *
      * @param program The Ghidra program to get the address space from
      * @param addressString The address string to validate
      * @return true if the address string can be parsed, false otherwise
@@ -87,7 +93,7 @@ public class AddressUtil {
      * Resolve an address or symbol string to an Address object.
      * This method first attempts to find a symbol with the given name,
      * and if not found, falls back to parsing it as an address.
-     * 
+     *
      * @param program The Ghidra program to search in
      * @param addressOrSymbol The address string (with or without "0x") or symbol name
      * @return The resolved Address object, or null if neither symbol nor address is valid
@@ -98,23 +104,23 @@ public class AddressUtil {
         }
 
         String input = addressOrSymbol.trim();
-        
+
         // First, try to find it as a symbol
         SymbolTable symbolTable = program.getSymbolTable();
         List<Symbol> symbols = symbolTable.getLabelOrFunctionSymbols(input, null);
-        
+
         if (!symbols.isEmpty()) {
             // Return the address of the first matching symbol
             return symbols.get(0).getAddress();
         }
-        
+
         // If not found as a symbol, try to parse as an address
         return parseAddress(program, input);
     }
 
     /**
      * Get the function containing the given address.
-     * 
+     *
      * @param program The Ghidra program
      * @param address The address to check
      * @return The containing function, or null if the address is not within a function
@@ -123,13 +129,13 @@ public class AddressUtil {
         if (program == null || address == null) {
             return null;
         }
-        
+
         return program.getFunctionManager().getFunctionContaining(address);
     }
 
     /**
      * Get the data item containing or starting at the given address.
-     * 
+     *
      * @param program The Ghidra program
      * @param address The address to check
      * @return The data at or containing the address, or null if no data exists there
@@ -138,15 +144,15 @@ public class AddressUtil {
         if (program == null || address == null) {
             return null;
         }
-        
+
         Listing listing = program.getListing();
-        
+
         // First check if there's data exactly at this address
         Data data = listing.getDataAt(address);
         if (data != null) {
             return data;
         }
-        
+
         // If not, check if this address is within a larger data structure
         return listing.getDataContaining(address);
     }

--- a/src/main/java/reva/util/AddressUtil.java
+++ b/src/main/java/reva/util/AddressUtil.java
@@ -42,11 +42,7 @@ public class AddressUtil {
         if (address == null) {
             return null;
         }
-        // Ensure we have an actual Address object and format it properly
-        if (!(address instanceof Address)) {
-            throw new IllegalArgumentException("Expected Address object, got: " + address.getClass().getName());
-        }
-
+        // Format the address with a consistent "0x" prefix
         // address with a 0x prefix.
         return address.toString("0x");
     }

--- a/src/main/java/reva/util/DecompilationContextUtil.java
+++ b/src/main/java/reva/util/DecompilationContextUtil.java
@@ -1,0 +1,279 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reva.util;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import ghidra.app.decompiler.ClangLine;
+import ghidra.app.decompiler.ClangToken;
+import ghidra.app.decompiler.ClangTokenGroup;
+import ghidra.app.decompiler.DecompInterface;
+import ghidra.app.decompiler.DecompileResults;
+import ghidra.app.decompiler.DecompiledFunction;
+import ghidra.app.decompiler.component.DecompilerUtils;
+import ghidra.program.model.address.Address;
+import ghidra.program.model.listing.Function;
+import ghidra.program.model.listing.Program;
+import ghidra.program.model.symbol.Reference;
+import ghidra.program.model.symbol.ReferenceIterator;
+import ghidra.util.Msg;
+import ghidra.util.task.TaskMonitor;
+
+/**
+ * Utility class for working with decompilation context and cross references.
+ * Provides methods to map addresses to decompilation line numbers and extract
+ * code context around specific lines.
+ */
+public class DecompilationContextUtil {
+
+    /**
+     * Get the decompilation line number for a specific address within a function.
+     * 
+     * @param program The Ghidra program
+     * @param function The function containing the address
+     * @param address The address to find the line number for
+     * @return The line number (1-based) or -1 if not found
+     */
+    public static int getLineNumberForAddress(Program program, Function function, Address address) {
+        if (program == null || function == null || address == null) {
+            return -1;
+        }
+
+        // Initialize decompiler
+        DecompInterface decompiler = new DecompInterface();
+        decompiler.toggleCCode(true);
+        decompiler.toggleSyntaxTree(true);
+        decompiler.setSimplificationStyle("decompile");
+
+        if (!decompiler.openProgram(program)) {
+            return -1;
+        }
+
+        try {
+            // Decompile the function
+            DecompileResults decompileResults = decompiler.decompileFunction(function, 0, TaskMonitor.DUMMY);
+            if (!decompileResults.decompileCompleted()) {
+                return -1;
+            }
+
+            // Get the markup for line mapping
+            ClangTokenGroup markup = decompileResults.getCCodeMarkup();
+            List<ClangLine> clangLines = DecompilerUtils.toLines(markup);
+
+            // Find the line containing this address
+            for (ClangLine clangLine : clangLines) {
+                List<ClangToken> tokens = clangLine.getAllTokens();
+                for (ClangToken token : tokens) {
+                    Address tokenAddr = token.getMinAddress();
+                    if (tokenAddr != null && tokenAddr.equals(address)) {
+                        return clangLine.getLineNumber();
+                    }
+                }
+
+                // If no exact match, check if address is within the range of this line
+                if (!tokens.isEmpty()) {
+                    Address closestAddr = DecompilerUtils.getClosestAddress(program, tokens.get(0));
+                    if (closestAddr != null && closestAddr.equals(address)) {
+                        return clangLine.getLineNumber();
+                    }
+                }
+            }
+
+            return -1;
+        } catch (Exception e) {
+            Msg.error(DecompilationContextUtil.class, "Error getting line number for address " + address, e);
+            return -1;
+        } finally {
+            decompiler.dispose();
+        }
+    }
+
+    /**
+     * Get a context snippet around a specific line in a function's decompilation.
+     * 
+     * @param program The Ghidra program
+     * @param function The function to decompile
+     * @param lineNumber The target line number (1-based)
+     * @param contextLines Number of lines to include before and after the target line
+     * @return A string containing the context lines separated by newlines, or null if error
+     */
+    public static String getDecompilationContext(Program program, Function function, int lineNumber, int contextLines) {
+        if (program == null || function == null || lineNumber <= 0 || contextLines < 0) {
+            return null;
+        }
+
+        // Initialize decompiler
+        DecompInterface decompiler = new DecompInterface();
+        decompiler.toggleCCode(true);
+        decompiler.toggleSyntaxTree(true);
+        decompiler.setSimplificationStyle("decompile");
+
+        if (!decompiler.openProgram(program)) {
+            return null;
+        }
+
+        try {
+            // Decompile the function
+            DecompileResults decompileResults = decompiler.decompileFunction(function, 0, TaskMonitor.DUMMY);
+            if (!decompileResults.decompileCompleted()) {
+                return null;
+            }
+
+            // Get the decompiled code
+            DecompiledFunction decompiledFunction = decompileResults.getDecompiledFunction();
+            String decompCode = decompiledFunction.getC();
+            String[] lines = decompCode.split("\n");
+
+            // Calculate range
+            int startLine = Math.max(0, lineNumber - 1 - contextLines); // Convert to 0-based
+            int endLine = Math.min(lines.length - 1, lineNumber - 1 + contextLines);
+
+            // Build context string
+            StringBuilder context = new StringBuilder();
+            for (int i = startLine; i <= endLine; i++) {
+                if (i > startLine) {
+                    context.append("\n");
+                }
+                context.append(lines[i]);
+            }
+
+            return context.toString();
+        } catch (Exception e) {
+            Msg.error(DecompilationContextUtil.class, "Error getting decompilation context", e);
+            return null;
+        } finally {
+            decompiler.dispose();
+        }
+    }
+
+    /**
+     * Get enhanced incoming reference information for a function with line numbers and optional context.
+     * 
+     * @param program The Ghidra program
+     * @param targetFunction The function to get incoming references for
+     * @param includeContext Whether to include code context snippets
+     * @return List of enhanced reference maps
+     */
+    public static List<Map<String, Object>> getEnhancedIncomingReferences(Program program, Function targetFunction, boolean includeContext) {
+        List<Map<String, Object>> enhancedRefs = new ArrayList<>();
+
+        if (program == null || targetFunction == null) {
+            return enhancedRefs;
+        }
+
+        try {
+            // Get references to this function's entry point
+            ReferenceIterator incomingRefs = program.getReferenceManager().getReferencesTo(targetFunction.getEntryPoint());
+
+            while (incomingRefs.hasNext()) {
+                Reference ref = incomingRefs.next();
+                Address fromAddress = ref.getFromAddress();
+                Function fromFunction = program.getFunctionManager().getFunctionContaining(fromAddress);
+
+                Map<String, Object> refInfo = new HashMap<>();
+                refInfo.put("fromAddress", AddressUtil.formatAddress(fromAddress));
+                refInfo.put("referenceType", ref.getReferenceType().toString());
+
+                if (fromFunction != null) {
+                    refInfo.put("fromFunction", fromFunction.getName());
+
+                    // Get line number in the source function
+                    int lineNumber = getLineNumberForAddress(program, fromFunction, fromAddress);
+                    if (lineNumber > 0) {
+                        refInfo.put("fromLine", lineNumber);
+
+                        // Add context if requested
+                        if (includeContext) {
+                            String context = getDecompilationContext(program, fromFunction, lineNumber, 1);
+                            if (context != null) {
+                                refInfo.put("context", context);
+                            }
+                        }
+                    }
+                }
+
+                enhancedRefs.add(refInfo);
+            }
+        } catch (Exception e) {
+            Msg.error(DecompilationContextUtil.class, "Error getting enhanced incoming references", e);
+        }
+
+        return enhancedRefs;
+    }
+
+    /**
+     * Get enhanced reference information for any address with line numbers and optional context.
+     * This method can be used by cross reference tools to add decompilation context.
+     * 
+     * @param program The Ghidra program
+     * @param targetAddress The address to get references to
+     * @param includeContext Whether to include code context snippets
+     * @return List of enhanced reference maps
+     */
+    public static List<Map<String, Object>> getEnhancedReferencesTo(Program program, Address targetAddress, boolean includeContext) {
+        List<Map<String, Object>> enhancedRefs = new ArrayList<>();
+
+        if (program == null || targetAddress == null) {
+            return enhancedRefs;
+        }
+
+        try {
+            // Get references to this address
+            ReferenceIterator refs = program.getReferenceManager().getReferencesTo(targetAddress);
+
+            while (refs.hasNext()) {
+                Reference ref = refs.next();
+                Address fromAddress = ref.getFromAddress();
+                Function fromFunction = program.getFunctionManager().getFunctionContaining(fromAddress);
+
+                Map<String, Object> refInfo = new HashMap<>();
+                refInfo.put("fromAddress", AddressUtil.formatAddress(fromAddress));
+                refInfo.put("toAddress", AddressUtil.formatAddress(ref.getToAddress()));
+                refInfo.put("referenceType", ref.getReferenceType().toString());
+                refInfo.put("isPrimary", ref.isPrimary());
+                refInfo.put("operandIndex", ref.getOperandIndex());
+                refInfo.put("sourceType", ref.getSource().toString());
+
+                if (fromFunction != null) {
+                    refInfo.put("fromFunction", fromFunction.getName());
+
+                    // Get line number in the source function
+                    int lineNumber = getLineNumberForAddress(program, fromFunction, fromAddress);
+                    if (lineNumber > 0) {
+                        refInfo.put("fromLine", lineNumber);
+
+                        // Add context if requested
+                        if (includeContext) {
+                            String context = getDecompilationContext(program, fromFunction, lineNumber, 1);
+                            if (context != null) {
+                                refInfo.put("context", context);
+                            }
+                        }
+                    }
+                }
+
+                enhancedRefs.add(refInfo);
+            }
+        } catch (Exception e) {
+            Msg.error(DecompilationContextUtil.class, "Error getting enhanced references to address", e);
+        }
+
+        return enhancedRefs;
+    }
+}

--- a/src/main/java/reva/util/DecompilationContextUtil.java
+++ b/src/main/java/reva/util/DecompilationContextUtil.java
@@ -32,6 +32,7 @@ import ghidra.program.model.listing.Function;
 import ghidra.program.model.listing.Program;
 import ghidra.program.model.symbol.Reference;
 import ghidra.program.model.symbol.ReferenceIterator;
+import ghidra.program.model.symbol.Symbol;
 import ghidra.util.Msg;
 import ghidra.util.task.TaskMonitor;
 
@@ -44,7 +45,7 @@ public class DecompilationContextUtil {
 
     /**
      * Get the decompilation line number for a specific address within a function.
-     * 
+     *
      * @param program The Ghidra program
      * @param function The function containing the address
      * @param address The address to find the line number for
@@ -106,7 +107,7 @@ public class DecompilationContextUtil {
 
     /**
      * Get a context snippet around a specific line in a function's decompilation.
-     * 
+     *
      * @param program The Ghidra program
      * @param function The function to decompile
      * @param lineNumber The target line number (1-based)
@@ -164,7 +165,7 @@ public class DecompilationContextUtil {
 
     /**
      * Get enhanced incoming reference information for a function with line numbers and optional context.
-     * 
+     *
      * @param program The Ghidra program
      * @param targetFunction The function to get incoming references for
      * @param includeContext Whether to include code context snippets
@@ -189,6 +190,15 @@ public class DecompilationContextUtil {
                 Map<String, Object> refInfo = new HashMap<>();
                 refInfo.put("fromAddress", AddressUtil.formatAddress(fromAddress));
                 refInfo.put("referenceType", ref.getReferenceType().toString());
+
+                // Add symbol name if available
+                if (fromAddress != null) {
+                    Symbol fromSymbol = program.getSymbolTable().getPrimarySymbol(fromAddress);
+                    if (fromSymbol != null) {
+                        refInfo.put("fromSymbol", fromSymbol.getName());
+                        refInfo.put("fromSymbolType", fromSymbol.getSymbolType().toString());
+                    }
+                }
 
                 if (fromFunction != null) {
                     refInfo.put("fromFunction", fromFunction.getName());
@@ -220,7 +230,7 @@ public class DecompilationContextUtil {
     /**
      * Get enhanced reference information for any address with line numbers and optional context.
      * This method can be used by cross reference tools to add decompilation context.
-     * 
+     *
      * @param program The Ghidra program
      * @param targetAddress The address to get references to
      * @param includeContext Whether to include code context snippets

--- a/src/test.slow/java/reva/RevaIntegrationTestBase.java
+++ b/src/test.slow/java/reva/RevaIntegrationTestBase.java
@@ -44,9 +44,8 @@ import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.ClientCapabilities;
 import io.modelcontextprotocol.spec.McpSchema.ListToolsResult;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
-
+import reva.plugin.ConfigManager;
 import reva.plugin.RevaPlugin;
-import reva.util.ConfigManager;
 import reva.server.McpServerManager;
 
 /**
@@ -63,7 +62,7 @@ public abstract class RevaIntegrationTestBase extends AbstractGhidraHeadedIntegr
     private static ConfigManager sharedConfigManager;
     private static McpServerManager sharedServerManager;
     private static ObjectMapper sharedObjectMapper;
-    
+
     // Per-test instances
     public TestEnv env;
     protected PluginTool tool;
@@ -77,18 +76,18 @@ public abstract class RevaIntegrationTestBase extends AbstractGhidraHeadedIntegr
     /**
      * Set up shared test environment once for all tests in the class.
      * This significantly speeds up test execution by reusing the Ghidra instance.
-     * 
-     * Note: TestEnv, MCP server, and plugin initialization must be done lazily in @Before 
-     * method due to Ghidra system initialization requirements, but we can prepare 
+     *
+     * Note: TestEnv, MCP server, and plugin initialization must be done lazily in @Before
+     * method due to Ghidra system initialization requirements, but we can prepare
      * non-Ghidra dependent shared resources here to reduce per-test overhead.
      */
     @BeforeClass
     public static void setUpSharedTestEnvironment() throws Exception {
         // Initialize shared object mapper for JSON parsing across all tests
         sharedObjectMapper = new ObjectMapper();
-        
+
         // Pre-configure any other non-Ghidra dependent shared resources here
-        // This reduces per-test initialization overhead even though the main 
+        // This reduces per-test initialization overhead even though the main
         // Ghidra/MCP setup must still be done lazily in @Before
     }
 
@@ -99,12 +98,12 @@ public abstract class RevaIntegrationTestBase extends AbstractGhidraHeadedIntegr
         // Create and register shared ConfigManager
         sharedConfigManager = new ConfigManager(sharedTool);
         reva.util.RevaInternalServiceRegistry.registerService(ConfigManager.class, sharedConfigManager);
-        
+
         // Create and register shared McpServerManager
         sharedServerManager = new McpServerManager(sharedTool);
         reva.util.RevaInternalServiceRegistry.registerService(McpServerManager.class, sharedServerManager);
         reva.util.RevaInternalServiceRegistry.registerService(reva.services.RevaMcpService.class, sharedServerManager);
-        
+
         // Start the shared MCP server
         sharedServerManager.startServer();
     }

--- a/src/test.slow/java/reva/plugin/RevaPluginMcpIntegrationTest.java
+++ b/src/test.slow/java/reva/plugin/RevaPluginMcpIntegrationTest.java
@@ -37,7 +37,6 @@ import io.modelcontextprotocol.spec.McpSchema.ListToolsResult;
 import io.modelcontextprotocol.spec.McpSchema.Tool;
 
 import reva.RevaIntegrationTestBase;
-import reva.util.ConfigManager;
 
 /**
  * Integration tests for the MCP server functionality in RevaPlugin

--- a/src/test.slow/java/reva/tools/decompiler/DecompilerToolProviderIntegrationTest.java
+++ b/src/test.slow/java/reva/tools/decompiler/DecompilerToolProviderIntegrationTest.java
@@ -392,7 +392,7 @@ public class DecompilerToolProviderIntegrationTest extends RevaIntegrationTestBa
     }
 
     @Test
-    public void testGetDecompiledFunctionWithInvalidFunction() throws Exception {
+    public void testGetDecompilationWithInvalidFunction() throws Exception {
         withMcpClient(createMcpTransport(), client -> {
             client.initialize();
 
@@ -721,6 +721,65 @@ public class DecompilerToolProviderIntegrationTest extends RevaIntegrationTestBa
             // Restore the original config value
             configManager.setMaxDecompilerSearchFunctions(originalMax);
         }
+    }
+
+    @Test
+    public void testGetDecompilationReferencesContainSymbolAndAddress() throws Exception {
+        // Create a caller function that references testFunction
+        Address callerAddr = program.getAddressFactory().getDefaultAddressSpace().getAddress(0x01000200);
+        FunctionManager functionManager = program.getFunctionManager();
+        int txId = program.startTransaction("Create Caller Function");
+        try {
+            // Create a simple caller function
+            Function callerFunction = functionManager.createFunction("callerFunction", callerAddr,
+                program.getAddressFactory().getAddressSet(callerAddr, callerAddr.add(20)),
+                SourceType.USER_DEFINED);
+            // Insert a call instruction from callerFunction to testFunction
+            // For x86, 0xE8 is CALL rel32. We'll use a dummy relative offset (not actually executable, but enough for Ghidra to create a reference)
+            byte[] callInstr = new byte[] { (byte)0xE8, 0x00, 0x00, 0x00, 0x00 }; // CALL +0
+            program.getMemory().setBytes(callerAddr, callInstr);
+            // Add a reference from the call instruction to testFunction
+            program.getReferenceManager().addMemoryReference(
+                callerAddr, // from
+                testFunction.getEntryPoint(), // to
+                ghidra.program.model.symbol.RefType.UNCONDITIONAL_CALL,
+                ghidra.program.model.symbol.SourceType.USER_DEFINED,
+                0
+            );
+        } finally {
+            program.endTransaction(txId, true);
+        }
+
+        withMcpClient(createMcpTransport(), client -> {
+            client.initialize();
+
+            Map<String, Object> args = new HashMap<>();
+            args.put("programPath", programPath);
+            args.put("functionNameOrAddress", "testFunction");
+            args.put("includeIncomingReferences", true);
+            args.put("includeReferenceContext", false);
+            CallToolResult result = client.callTool(new CallToolRequest("get-decompilation", args));
+            assertNotNull("Result should not be null", result);
+            assertMcpResultNotError(result, "Result should not be an error");
+            TextContent content = (TextContent) result.content().get(0);
+            JsonNode json = parseJsonContent(content.text());
+            assertTrue("Should have incomingReferences", json.has("incomingReferences"));
+            JsonNode refs = json.get("incomingReferences");
+            boolean foundCaller = false;
+            for (JsonNode ref : refs) {
+                // Should have both fromAddress and fromSymbol fields (fromSymbol may be null if no symbol)
+                assertTrue("Reference should have fromAddress", ref.has("fromAddress"));
+                assertTrue("Reference should have referenceType", ref.has("referenceType"));
+                // fromSymbol is optional but if present, should be a string
+                if (ref.has("fromSymbol")) {
+                    assertTrue("fromSymbol should be a string if present", ref.get("fromSymbol").isTextual());
+                    if ("callerFunction".equals(ref.get("fromSymbol").asText())) {
+                        foundCaller = true;
+                    }
+                }
+            }
+            assertTrue("Should have a reference from callerFunction", foundCaller);
+        });
     }
 
 

--- a/src/test/java/reva/util/AddressUtilTest.java
+++ b/src/test/java/reva/util/AddressUtilTest.java
@@ -61,24 +61,12 @@ public class AddressUtilTest {
     }
 
     /**
-     * Test formatAddress with valid address
-     */
-    @Test
-    public void testFormatAddress_ValidAddress() {
-        when(address.toString()).thenReturn("00401000");
-        
-        String result = AddressUtil.formatAddress(address);
-        
-        assertEquals("0x00401000", result);
-    }
-
-    /**
      * Test formatAddress with null address
      */
     @Test
     public void testFormatAddress_NullAddress() {
         String result = AddressUtil.formatAddress(null);
-        
+
         assertNull(result);
     }
 
@@ -89,9 +77,9 @@ public class AddressUtilTest {
     public void testParseAddress_WithHexPrefix() {
         String addressString = "0x00401000";
         when(addressSpace.getAddress(0x00401000L)).thenReturn(address);
-        
+
         Address result = AddressUtil.parseAddress(program, addressString);
-        
+
         assertEquals(address, result);
     }
 
@@ -102,9 +90,9 @@ public class AddressUtilTest {
     public void testParseAddress_WithoutHexPrefix() {
         String addressString = "00401000";
         when(addressSpace.getAddress(0x00401000L)).thenReturn(address);
-        
+
         Address result = AddressUtil.parseAddress(program, addressString);
-        
+
         assertEquals(address, result);
     }
 
@@ -115,9 +103,9 @@ public class AddressUtilTest {
     public void testParseAddress_UppercaseHex() {
         String addressString = "0xDEADBEEF";
         when(addressSpace.getAddress(0xDEADBEEFL)).thenReturn(address);
-        
+
         Address result = AddressUtil.parseAddress(program, addressString);
-        
+
         assertEquals(address, result);
     }
 
@@ -127,7 +115,7 @@ public class AddressUtilTest {
     @Test
     public void testParseAddress_NullInput() {
         Address result = AddressUtil.parseAddress(program, null);
-        
+
         assertNull(result);
     }
 
@@ -137,7 +125,7 @@ public class AddressUtilTest {
     @Test
     public void testParseAddress_EmptyString() {
         Address result = AddressUtil.parseAddress(program, "");
-        
+
         assertNull(result);
     }
 
@@ -147,7 +135,7 @@ public class AddressUtilTest {
     @Test
     public void testParseAddress_Whitespace() {
         Address result = AddressUtil.parseAddress(program, "   ");
-        
+
         assertNull(result);
     }
 
@@ -157,9 +145,9 @@ public class AddressUtilTest {
     @Test
     public void testParseAddress_InvalidHex() {
         String addressString = "0xGHIJKL";
-        
+
         Address result = AddressUtil.parseAddress(program, addressString);
-        
+
         assertNull(result);
     }
 
@@ -170,9 +158,9 @@ public class AddressUtilTest {
     public void testIsValidAddress_ValidAddress() {
         String addressString = "0x00401000";
         when(addressSpace.getAddress(0x00401000L)).thenReturn(address);
-        
+
         boolean result = AddressUtil.isValidAddress(program, addressString);
-        
+
         assertTrue(result);
     }
 
@@ -182,9 +170,9 @@ public class AddressUtilTest {
     @Test
     public void testIsValidAddress_InvalidAddress() {
         String addressString = "invalid";
-        
+
         boolean result = AddressUtil.isValidAddress(program, addressString);
-        
+
         assertFalse(result);
     }
 
@@ -196,13 +184,13 @@ public class AddressUtilTest {
         String symbolName = "main";
         List<Symbol> symbols = new ArrayList<>();
         symbols.add(symbol);
-        
+
         when(program.getSymbolTable()).thenReturn(symbolTable);
         when(symbolTable.getLabelOrFunctionSymbols(symbolName, null)).thenReturn(symbols);
         when(symbol.getAddress()).thenReturn(address);
-        
+
         Address result = AddressUtil.resolveAddressOrSymbol(program, symbolName);
-        
+
         assertEquals(address, result);
     }
 
@@ -213,13 +201,13 @@ public class AddressUtilTest {
     public void testResolveAddressOrSymbol_Address() {
         String addressString = "0x00401000";
         List<Symbol> symbols = new ArrayList<>(); // Empty list
-        
+
         when(program.getSymbolTable()).thenReturn(symbolTable);
         when(symbolTable.getLabelOrFunctionSymbols(addressString, null)).thenReturn(symbols);
         when(addressSpace.getAddress(0x00401000L)).thenReturn(address);
-        
+
         Address result = AddressUtil.resolveAddressOrSymbol(program, addressString);
-        
+
         assertEquals(address, result);
     }
 
@@ -229,7 +217,7 @@ public class AddressUtilTest {
     @Test
     public void testResolveAddressOrSymbol_NullInput() {
         Address result = AddressUtil.resolveAddressOrSymbol(program, null);
-        
+
         assertNull(result);
     }
 
@@ -239,7 +227,7 @@ public class AddressUtilTest {
     @Test
     public void testResolveAddressOrSymbol_EmptyString() {
         Address result = AddressUtil.resolveAddressOrSymbol(program, "");
-        
+
         assertNull(result);
     }
 
@@ -250,13 +238,13 @@ public class AddressUtilTest {
     public void testResolveAddressOrSymbol_InvalidInput() {
         String input = "invalid";
         List<Symbol> symbols = new ArrayList<>(); // Empty list
-        
+
         when(program.getSymbolTable()).thenReturn(symbolTable);
         when(symbolTable.getLabelOrFunctionSymbols(input, null)).thenReturn(symbols);
         // parseAddress will return null for invalid input
-        
+
         Address result = AddressUtil.resolveAddressOrSymbol(program, input);
-        
+
         assertNull(result);
     }
 
@@ -267,9 +255,9 @@ public class AddressUtilTest {
     public void testGetContainingFunction_InsideFunction() {
         when(program.getFunctionManager()).thenReturn(functionManager);
         when(functionManager.getFunctionContaining(address)).thenReturn(function);
-        
+
         Function result = AddressUtil.getContainingFunction(program, address);
-        
+
         assertEquals(function, result);
     }
 
@@ -280,9 +268,9 @@ public class AddressUtilTest {
     public void testGetContainingFunction_OutsideFunction() {
         when(program.getFunctionManager()).thenReturn(functionManager);
         when(functionManager.getFunctionContaining(address)).thenReturn(null);
-        
+
         Function result = AddressUtil.getContainingFunction(program, address);
-        
+
         assertNull(result);
     }
 
@@ -292,7 +280,7 @@ public class AddressUtilTest {
     @Test
     public void testGetContainingFunction_NullProgram() {
         Function result = AddressUtil.getContainingFunction(null, address);
-        
+
         assertNull(result);
     }
 
@@ -302,7 +290,7 @@ public class AddressUtilTest {
     @Test
     public void testGetContainingFunction_NullAddress() {
         Function result = AddressUtil.getContainingFunction(program, null);
-        
+
         assertNull(result);
     }
 
@@ -313,9 +301,9 @@ public class AddressUtilTest {
     public void testGetContainingData_ExactAddress() {
         when(program.getListing()).thenReturn(listing);
         when(listing.getDataAt(address)).thenReturn(data);
-        
+
         Data result = AddressUtil.getContainingData(program, address);
-        
+
         assertEquals(data, result);
     }
 
@@ -327,9 +315,9 @@ public class AddressUtilTest {
         when(program.getListing()).thenReturn(listing);
         when(listing.getDataAt(address)).thenReturn(null);
         when(listing.getDataContaining(address)).thenReturn(data);
-        
+
         Data result = AddressUtil.getContainingData(program, address);
-        
+
         assertEquals(data, result);
     }
 
@@ -341,9 +329,9 @@ public class AddressUtilTest {
         when(program.getListing()).thenReturn(listing);
         when(listing.getDataAt(address)).thenReturn(null);
         when(listing.getDataContaining(address)).thenReturn(null);
-        
+
         Data result = AddressUtil.getContainingData(program, address);
-        
+
         assertNull(result);
     }
 
@@ -353,7 +341,7 @@ public class AddressUtilTest {
     @Test
     public void testGetContainingData_NullProgram() {
         Data result = AddressUtil.getContainingData(null, address);
-        
+
         assertNull(result);
     }
 
@@ -363,7 +351,7 @@ public class AddressUtilTest {
     @Test
     public void testGetContainingData_NullAddress() {
         Data result = AddressUtil.getContainingData(program, null);
-        
+
         assertNull(result);
     }
 
@@ -374,9 +362,9 @@ public class AddressUtilTest {
     public void testParseAddress_VeryLargeHex() {
         String addressString = "0xFFFFFFFFFFFFFFFF";
         when(addressSpace.getAddress(0xFFFFFFFFFFFFFFFFL)).thenReturn(address);
-        
+
         Address result = AddressUtil.parseAddress(program, addressString);
-        
+
         assertEquals(address, result);
     }
 
@@ -387,9 +375,9 @@ public class AddressUtilTest {
     public void testParseAddress_WithSpaces() {
         String addressString = "  0x00401000  ";
         when(addressSpace.getAddress(0x00401000L)).thenReturn(address);
-        
+
         Address result = AddressUtil.parseAddress(program, addressString);
-        
+
         assertEquals(address, result);
     }
 
@@ -401,13 +389,13 @@ public class AddressUtilTest {
         String symbolName = "Main"; // Different case than "main"
         List<Symbol> symbols = new ArrayList<>();
         symbols.add(symbol);
-        
+
         when(program.getSymbolTable()).thenReturn(symbolTable);
         when(symbolTable.getLabelOrFunctionSymbols(symbolName, null)).thenReturn(symbols);
         when(symbol.getAddress()).thenReturn(address);
-        
+
         Address result = AddressUtil.resolveAddressOrSymbol(program, symbolName);
-        
+
         assertEquals(address, result);
     }
 
@@ -420,17 +408,17 @@ public class AddressUtilTest {
         List<Symbol> symbols = new ArrayList<>();
         Symbol symbol2 = mock(Symbol.class);
         Address address2 = mock(Address.class);
-        
+
         symbols.add(symbol);
         symbols.add(symbol2);
-        
+
         when(program.getSymbolTable()).thenReturn(symbolTable);
         when(symbolTable.getLabelOrFunctionSymbols(symbolName, null)).thenReturn(symbols);
         when(symbol.getAddress()).thenReturn(address);
         when(symbol2.getAddress()).thenReturn(address2);
-        
+
         Address result = AddressUtil.resolveAddressOrSymbol(program, symbolName);
-        
+
         assertEquals(address, result); // Should return first symbol's address
     }
 }


### PR DESCRIPTION
Add decompiler context snippets to help drive the LLM to only search interesting cross references in functions.

The decompiler search can be slow on large programs. Add a config option to limit the search tool to smaller programs with small function counts.

Add an option to the tool so the LLM can override the limit and some guidance to try cross references instead.