### PR TITLE
Only display Application plugin in the Project view

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,12 @@ export GHIDRA_INSTALL_DIR=/path/to/ghidra
 gradle
 ```
 
-Then install the extension (in `dist/`) using the Ghidra extension manager.
+Then install the extension (in `dist/`) using the Ghidra extension manager. You can also extract the release zip to
+the Ghidra extensions directory globally at `${GHIDRA_INSTALL_DIR}/Ghidra/Extensions`.
+
+After installing the extension you need to activate it in two places:
+1. In the Project view, open the File menu and select "Configure". Click the "Configure all plugins" button on the top right of the menu (it looks like a plug). Check the "ReVa Application Plugin"
+2. In the Code Browser tool (Click the Dragon icon or open a File), open the File menu and select "Configure". Click the "Configure all plugins" button on the top right of the menu (it looks like a plug). Check the "ReVa Plugin". Then Press File and select "Save Tool". This will enable ReVa by default.
 
 ## MCP configuration
 ReVa uses the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/faqs) to communicate with the LLM.

--- a/extension.properties
+++ b/extension.properties
@@ -1,5 +1,5 @@
 name=ReVa
 description=Reverse Engineering Assistant
-author=
+author=CyberKaida
 createdOn=
 version=@extversion@

--- a/src/main/java/reva/plugin/RevaApplicationPlugin.java
+++ b/src/main/java/reva/plugin/RevaApplicationPlugin.java
@@ -16,7 +16,7 @@
 package reva.plugin;
 
 import ghidra.app.plugin.PluginCategoryNames;
-import ghidra.framework.main.ApplicationLevelPlugin;
+import ghidra.framework.main.ApplicationLevelOnlyPlugin;
 import ghidra.framework.main.FrontEndService;
 import ghidra.framework.model.Project;
 import ghidra.framework.model.ProjectListener;
@@ -38,7 +38,7 @@ import reva.util.RevaInternalServiceRegistry;
  * running even when individual analysis tools are closed and reopened.
  */
 @PluginInfo(
-    status = PluginStatus.STABLE,
+    status = PluginStatus.RELEASED,
     packageName = "ReVa",
     category = PluginCategoryNames.COMMON,
     shortDescription = "ReVa Application Manager",
@@ -46,7 +46,7 @@ import reva.util.RevaInternalServiceRegistry;
     servicesProvided = { RevaMcpService.class },
     servicesRequired = { FrontEndService.class }
 )
-public class RevaApplicationPlugin extends Plugin implements ApplicationLevelPlugin, ProjectListener {
+public class RevaApplicationPlugin extends Plugin implements ApplicationLevelOnlyPlugin, ProjectListener {
     private McpServerManager serverManager;
     private FrontEndService frontEndService;
     private Project currentProject;
@@ -66,10 +66,10 @@ public class RevaApplicationPlugin extends Plugin implements ApplicationLevelPlu
 
         // Initialize the MCP server manager
         serverManager = new McpServerManager(tool);
-        
+
         // Register the service
         registerServiceProvided(RevaMcpService.class, serverManager);
-        
+
         // Make server manager available via service registry for backward compatibility
         RevaInternalServiceRegistry.registerService(McpServerManager.class, serverManager);
         RevaInternalServiceRegistry.registerService(RevaMcpService.class, serverManager);
@@ -95,7 +95,7 @@ public class RevaApplicationPlugin extends Plugin implements ApplicationLevelPlu
                 if (serverManager != null) {
                     serverManager.shutdown();
                 }
-            }, 
+            },
             ShutdownPriority.FIRST.after()
         );
 
@@ -105,28 +105,28 @@ public class RevaApplicationPlugin extends Plugin implements ApplicationLevelPlu
     @Override
     protected void dispose() {
         Msg.info(this, "ReVa Application Plugin disposing...");
-        
+
         // Remove project listener
         if (frontEndService != null) {
             frontEndService.removeProjectListener(this);
             frontEndService = null;
         }
-        
+
         // Clean up any active project state
         Project activeProject = tool.getProjectManager().getActiveProject();
         if (activeProject != null) {
             projectClosed(activeProject);
         }
-        
+
         // Shutdown the MCP server
         if (serverManager != null) {
             serverManager.shutdown();
             serverManager = null;
         }
-        
+
         // Clear service registry
         RevaInternalServiceRegistry.clearAllServices();
-        
+
         super.dispose();
         Msg.info(this, "ReVa Application Plugin disposed");
     }

--- a/src/main/java/reva/plugin/RevaPlugin.java
+++ b/src/main/java/reva/plugin/RevaPlugin.java
@@ -35,9 +35,9 @@ import reva.util.RevaInternalServiceRegistry;
  * and handles program lifecycle events for this specific tool.
  */
 @PluginInfo(
-    status = PluginStatus.STABLE,
+    status = PluginStatus.RELEASED,
     packageName = "ReVa",
-    category = PluginCategoryNames.ANALYSIS,
+    category = PluginCategoryNames.COMMON,
     shortDescription = "Reverse Engineering Assistant (Tool)",
     description = "Tool-level ReVa plugin that connects to the application-level MCP server"
 )
@@ -63,12 +63,12 @@ public class RevaPlugin extends ProgramPlugin {
 
         // Get the MCP service from the application plugin
         mcpService = tool.getService(RevaMcpService.class);
-        
+
         // Fallback for testing environments where ApplicationLevelPlugin isn't available
         if (mcpService == null) {
             mcpService = RevaInternalServiceRegistry.getService(RevaMcpService.class);
         }
-        
+
         if (mcpService == null) {
             Msg.error(this, "RevaMcpService not available - RevaApplicationPlugin may not be loaded and no fallback service found");
             return;
@@ -89,7 +89,7 @@ public class RevaPlugin extends ProgramPlugin {
         Msg.info(this, "Program opened: " + program.getName());
         // Notify the program manager to handle cache management
         RevaProgramManager.programOpened(program);
-        
+
         // Notify the MCP service about the program opening in this tool
         if (mcpService != null) {
             mcpService.programOpened(program, tool);
@@ -101,7 +101,7 @@ public class RevaPlugin extends ProgramPlugin {
         Msg.info(this, "Program closed: " + program.getName());
         // Notify the program manager to clear stale cache
         RevaProgramManager.programClosed(program);
-        
+
         // Notify the MCP service about the program closing in this tool
         if (mcpService != null) {
             mcpService.programClosed(program, tool);


### PR DESCRIPTION
The Application level plugin only works in the Project view. It inhereted the wrong interface and appeared in the tool view. Update inheritence to only display in the Project view.

Fixes #149 