### PR TITLE
Add install task in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,20 @@ task distributeExtension {
 }
 //----------------------END "DO NOT MODIFY" SECTION-------------------------------
 
+task install(type: Exec) {
+    dependsOn buildExtension
+    
+    group = "Installation"
+    description = "Installs the zip package in installed Ghidra's default extension directory"
+
+    workingDir ghidraInstallDir + '/Ghidra/Extensions'
+    commandLine 'unzip', '-o', "${buildExtension.destinationDirectory.getAsFile().get().getAbsolutePath()}/${buildExtension.archiveBaseName.get()}.${buildExtension.archiveExtension.get()}"
+    
+    doLast {
+        logger.quiet("Installed ReVa")
+    }
+}
+
 sourceSets {
 	integrationTest {
 		java {


### PR DESCRIPTION
Adds a simple install task in the build.gradle that unzips and installs ReVa into the Ghidra installation specified by GHIDRA_INSTALL_DIR. This must be set for the install to work.

To try it out:
```
gradle install
```

Tested with Ghidra 11.4 and starting Ghidra in debug mode:
```
...
INFO  MCP server started successfully  (McpServerManager.java:202)
INFO  ReVa Application Plugin initialization complete - MCP server running at application level  (RevaApplicationPlugin.java:102)
INFO  Opening project: /Users/joncarloalvarado/Ghidra/sandbox  (DefaultProject.java:115)
INFO  restoring data storage index...  (IndexedLocalFileSystem.java:1465)
WARN  Can't find plugin package for ReVa! Creating stub...  (PluginPackage.java:63)
INFO  Packed database cache: /var/tmp/joncarloalvarado-ghidra/packed-db-cache  (PackedDatabaseCache.java:64)
DEBUG Using cached packed database: /Applications/Ghidra.app/Contents/Resources/ghidra_11.4.2_PUBLIC/Ghidra/Features/Base/data/typeinfo/mac_10.9/mac_osx.gdt  (PackedDatabaseCache.java:364)
DEBUG Using cached packed database: /Applications/Ghidra.app/Contents/Resources/ghidra_11.4.2_PUBLIC/Ghidra/Features/Base/data/typeinfo/generic/generic_clib_64.gdt  (PackedDatabaseCache.java:364)
INFO  Project opened: sandbox  (RevaApplicationPlugin.java:137)
INFO  Ghidra startup complete (5617 ms)  (GhidraRun.java:97)
^CINFO  Shutting down MCP server...  (McpServerManager.java:434)
DEBUG Removed config change listener: McpServerManager  (ConfigManager.java:145)
INFO  MCP server shutdown complete  (McpServerManager.java:477)
```