### PR TITLE
Drop Ghidra 11.3 support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,3 +148,4 @@ The server uses streamable transport (SSE) on port 8080 by default. Configuratio
 - **Read-Before-Modify**: Decompiler tools enforce function reading before modification
 - **Error Messages**: Provide specific, actionable error messages with suggestions
 - When reading the test report, use the read tool or grep, do not use `open`.
+- If you have compatibility problems and things do not compile because of jackson or the MCP SDK. `rm lib/*.jar` can help clean and fix these.

--- a/build.gradle
+++ b/build.gradle
@@ -108,7 +108,7 @@ repositories {
 dependencies {
 	// Any external dependencies added here will automatically be copied to the lib/ directory when
 	// this extension is built.
-	implementation platform("io.modelcontextprotocol.sdk:mcp-bom:0.12.0")
+	implementation platform("io.modelcontextprotocol.sdk:mcp-bom:0.12.1")
 	implementation "io.modelcontextprotocol.sdk:mcp"
 	implementation "jakarta.servlet:jakarta.servlet-api:6.1.0"
 	// Add Jetty for embedded servlet support

--- a/build.gradle
+++ b/build.gradle
@@ -108,7 +108,7 @@ repositories {
 dependencies {
 	// Any external dependencies added here will automatically be copied to the lib/ directory when
 	// this extension is built.
-	implementation platform("io.modelcontextprotocol.sdk:mcp-bom:0.11.2")
+	implementation platform("io.modelcontextprotocol.sdk:mcp-bom:0.12.0")
 	implementation "io.modelcontextprotocol.sdk:mcp"
 	implementation "jakarta.servlet:jakarta.servlet-api:6.1.0"
 	// Add Jetty for embedded servlet support

--- a/src/main/java/reva/tools/comments/CommentToolProvider.java
+++ b/src/main/java/reva/tools/comments/CommentToolProvider.java
@@ -25,6 +25,7 @@ import ghidra.program.model.address.AddressSet;
 import ghidra.program.model.address.AddressSetView;
 import ghidra.program.model.address.AddressIterator;
 import ghidra.program.model.listing.CodeUnit;
+import ghidra.program.model.listing.CommentType;
 import ghidra.program.model.listing.Program;
 import ghidra.program.model.listing.Listing;
 import ghidra.program.model.listing.CodeUnitIterator;
@@ -41,12 +42,12 @@ import reva.util.SchemaUtil;
  */
 public class CommentToolProvider extends AbstractToolProvider {
 
-    private static final Map<String, Integer> COMMENT_TYPES = Map.of(
-        "pre", CodeUnit.PRE_COMMENT,
-        "eol", CodeUnit.EOL_COMMENT,
-        "post", CodeUnit.POST_COMMENT,
-        "plate", CodeUnit.PLATE_COMMENT,
-        "repeatable", CodeUnit.REPEATABLE_COMMENT
+    private static final Map<String, CommentType> COMMENT_TYPES = Map.of(
+        "pre", CommentType.PRE,
+        "eol", CommentType.EOL,
+        "post", CommentType.POST,
+        "plate", CommentType.PLATE,
+        "repeatable", CommentType.REPEATABLE
     );
 
     /**
@@ -93,7 +94,7 @@ public class CommentToolProvider extends AbstractToolProvider {
             String commentTypeStr = getOptionalString(request, "commentType", "eol");
             String comment = getString(request, "comment");
 
-            Integer commentType = COMMENT_TYPES.get(commentTypeStr.toLowerCase());
+            CommentType commentType = COMMENT_TYPES.get(commentTypeStr.toLowerCase());
             if (commentType == null) {
                 return createErrorResult("Invalid comment type: " + commentTypeStr +
                     ". Must be one of: pre, eol, post, plate, repeatable");
@@ -187,10 +188,10 @@ public class CommentToolProvider extends AbstractToolProvider {
                 return createErrorResult("Either 'address' or 'addressRange' must be provided");
             }
 
-            List<Integer> types = new ArrayList<>();
+            List<CommentType> types = new ArrayList<>();
             if (commentTypes != null && !commentTypes.isEmpty()) {
                 for (String typeStr : commentTypes) {
-                    Integer type = COMMENT_TYPES.get(typeStr.toLowerCase());
+                    CommentType type = COMMENT_TYPES.get(typeStr.toLowerCase());
                     if (type == null) {
                         return createErrorResult("Invalid comment type: " + typeStr);
                     }
@@ -208,7 +209,7 @@ public class CommentToolProvider extends AbstractToolProvider {
                 CodeUnit codeUnit = codeUnits.next();
                 Address addr = codeUnit.getAddress();
 
-                for (int type : types) {
+                for (CommentType type : types) {
                     String comment = codeUnit.getComment(type);
                     if (comment != null && !comment.isEmpty()) {
                         Map<String, Object> commentInfo = new HashMap<>();
@@ -254,7 +255,7 @@ public class CommentToolProvider extends AbstractToolProvider {
             Address address = getAddressFromArgs(request, program, "addressOrSymbol");
             String commentTypeStr = getString(request, "commentType");
 
-            Integer commentType = COMMENT_TYPES.get(commentTypeStr.toLowerCase());
+            CommentType commentType = COMMENT_TYPES.get(commentTypeStr.toLowerCase());
             if (commentType == null) {
                 return createErrorResult("Invalid comment type: " + commentTypeStr +
                     ". Must be one of: pre, eol, post, plate, repeatable");
@@ -317,10 +318,10 @@ public class CommentToolProvider extends AbstractToolProvider {
             List<String> commentTypes = getOptionalStringList(request.arguments(), "commentTypes", null);
             int maxResults = getOptionalInt(request, "maxResults", 100);
 
-            List<Integer> types = new ArrayList<>();
+            List<CommentType> types = new ArrayList<>();
             if (commentTypes != null && !commentTypes.isEmpty()) {
                 for (String typeStr : commentTypes) {
-                    Integer type = COMMENT_TYPES.get(typeStr.toLowerCase());
+                    CommentType type = COMMENT_TYPES.get(typeStr.toLowerCase());
                     if (type == null) {
                         return createErrorResult("Invalid comment type: " + typeStr);
                     }
@@ -334,7 +335,7 @@ public class CommentToolProvider extends AbstractToolProvider {
             List<Map<String, Object>> results = new ArrayList<>();
             Listing listing = program.getListing();
 
-            for (int type : types) {
+            for (CommentType type : types) {
                 if (results.size() >= maxResults) break;
 
                 AddressIterator commentAddrs = listing.getCommentAddressIterator(
@@ -376,11 +377,11 @@ public class CommentToolProvider extends AbstractToolProvider {
 
     /**
      * Get the string name for a comment type constant
-     * @param commentType The comment type constant
+     * @param commentType The comment type enum
      * @return The string name
      */
-    private String getCommentTypeName(int commentType) {
-        for (Map.Entry<String, Integer> entry : COMMENT_TYPES.entrySet()) {
+    private String getCommentTypeName(CommentType commentType) {
+        for (Map.Entry<String, CommentType> entry : COMMENT_TYPES.entrySet()) {
             if (entry.getValue() == commentType) {
                 return entry.getKey();
             }

--- a/src/main/java/reva/tools/decompiler/DecompilerToolProvider.java
+++ b/src/main/java/reva/tools/decompiler/DecompilerToolProvider.java
@@ -37,6 +37,7 @@ import ghidra.app.decompiler.component.DecompilerUtils;
 import ghidra.program.model.address.Address;
 import ghidra.program.model.address.AddressSetView;
 import ghidra.program.model.listing.CodeUnit;
+import ghidra.program.model.listing.CommentType;
 import ghidra.program.model.listing.CodeUnitIterator;
 import ghidra.program.model.listing.Function;
 import ghidra.program.model.listing.FunctionIterator;
@@ -1206,17 +1207,17 @@ public class DecompilerToolProvider extends AbstractToolProvider {
 
                 // Get comments at these addresses
                 Listing listing = program.getListing();
-                Map<Integer, String> commentTypes = Map.of(
-                    CodeUnit.PRE_COMMENT, "pre",
-                    CodeUnit.EOL_COMMENT, "eol",
-                    CodeUnit.POST_COMMENT, "post",
-                    CodeUnit.PLATE_COMMENT, "plate",
-                    CodeUnit.REPEATABLE_COMMENT, "repeatable"
+                Map<CommentType, String> commentTypes = Map.of(
+                    CommentType.PRE, "pre",
+                    CommentType.EOL, "eol",
+                    CommentType.POST, "post",
+                    CommentType.PLATE, "plate",
+                    CommentType.REPEATABLE, "repeatable"
                 );
                 for (Address addr : lineAddresses) {
                     CodeUnit cu = listing.getCodeUnitAt(addr);
                     if (cu != null) {
-                        for (Map.Entry<Integer, String> entry : commentTypes.entrySet()) {
+                        for (Map.Entry<CommentType, String> entry : commentTypes.entrySet()) {
                             addCommentIfExists(comments, cu, entry.getKey(), entry.getValue(), addr);
                         }
                     }
@@ -1243,19 +1244,19 @@ public class DecompilerToolProvider extends AbstractToolProvider {
             AddressSetView body = function.getBody();
 
             CodeUnitIterator codeUnits = listing.getCodeUnits(body, true);
-            Map<Integer, String> commentTypes = Map.of(
-                CodeUnit.PRE_COMMENT, "pre",
-                CodeUnit.EOL_COMMENT, "eol",
-                CodeUnit.POST_COMMENT, "post",
-                CodeUnit.PLATE_COMMENT, "plate",
-                CodeUnit.REPEATABLE_COMMENT, "repeatable"
+            Map<CommentType, String> commentTypes = Map.of(
+                CommentType.PRE, "pre",
+                CommentType.EOL, "eol",
+                CommentType.POST, "post",
+                CommentType.PLATE, "plate",
+                CommentType.REPEATABLE, "repeatable"
             );
             while (codeUnits.hasNext()) {
                 CodeUnit cu = codeUnits.next();
                 Address addr = cu.getAddress();
 
                 // Check all comment types
-                for (Map.Entry<Integer, String> entry : commentTypes.entrySet()) {
+                for (Map.Entry<CommentType, String> entry : commentTypes.entrySet()) {
                     addCommentIfExists(comments, cu, entry.getKey(), entry.getValue(), addr);
                 }
             }
@@ -1275,7 +1276,7 @@ public class DecompilerToolProvider extends AbstractToolProvider {
      * @param address The address
      */
     private void addCommentIfExists(List<Map<String, Object>> comments, CodeUnit cu,
-            int commentType, String typeString, Address address) {
+            CommentType commentType, String typeString, Address address) {
         String comment = cu.getComment(commentType);
         if (comment != null && !comment.isEmpty()) {
             Map<String, Object> commentInfo = new HashMap<>();
@@ -1334,11 +1335,11 @@ public class DecompilerToolProvider extends AbstractToolProvider {
             String comment = getString(request, "comment");
 
             // Validate comment type
-            int commentType;
+            CommentType commentType;
             if ("pre".equals(commentTypeStr)) {
-                commentType = CodeUnit.PRE_COMMENT;
+                commentType = CommentType.PRE;
             } else if ("eol".equals(commentTypeStr)) {
-                commentType = CodeUnit.EOL_COMMENT;
+                commentType = CommentType.EOL;
             } else {
                 return createErrorResult("Invalid comment type: " + commentTypeStr +
                     ". Must be 'pre' or 'eol' for decompilation comments.");


### PR DESCRIPTION
Ghidra 11.4 changed the comment API, we will adopt the new API and drop support for Ghidra 11.3.

This will be for the next major release of ReVa.