### PR TITLE
Add "Run in Smithery" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # ReVa - Ghidra MCP Server for AI-Powered Reverse Engineering
 
+[![Run in Smithery](https://smithery.ai/badge/skills/cyberkaida)](https://smithery.ai/skills?ns=cyberkaida&utm_source=github&utm_medium=badge)
+
+
 > A Ghidra extension that provides a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/faqs) server for AI-assisted reverse engineering
 
 ReVa (Reverse Engineering Assistant) is a **Ghidra MCP server** that enables AI language models to interact with Ghidra's powerful reverse engineering capabilities. ReVa uses


### PR DESCRIPTION
## Add skill discoverability badge

Your 5 Claude skills are already indexed on [Smithery](https://smithery.ai), a directory of Claude Skills and MCP servers. This badge links users directly to your skills.

### Badge Preview
[![Run in Smithery](https://smithery.ai/badge/skills/cyberkaida)](https://smithery.ai/skills?ns=cyberkaida&utm_source=github&utm_medium=badge)

### Why add this?
- Users browsing your repo can discover and install your skills with one click
- No additional setup required - your skills are already listed

---

This is optional. Feel free to close if you prefer not to add external badges.