### PR TITLE
chore(deps): bump Jackson from 2.19.2 to 2.20.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,13 +80,13 @@ sourceSets {
 configurations {
 	integrationTestImplementation.extendsFrom testImplementation
 
-	// Force Jackson 2.19.2 to be compatible with MCP SDK v0.14.0
+	// Force Jackson 2.20.x to be compatible with MCP SDK v0.17.0
 	all {
 		resolutionStrategy {
-			force 'com.fasterxml.jackson.core:jackson-core:2.19.2'
-			force 'com.fasterxml.jackson.core:jackson-databind:2.19.2'
-			force 'com.fasterxml.jackson.core:jackson-annotations:2.19.2'
-			force 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.19.2'
+			force 'com.fasterxml.jackson.core:jackson-core:2.20.1'
+			force 'com.fasterxml.jackson.core:jackson-databind:2.20.1'
+			force 'com.fasterxml.jackson.core:jackson-annotations:2.20'  // 2.20 dropped patch versions
+			force 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.20.1'
 		}
 	}
 }
@@ -116,10 +116,10 @@ dependencies {
 	implementation "org.eclipse.jetty:jetty-server:11.0.26"
 	implementation "org.eclipse.jetty:jetty-servlet:11.0.26"
 
-	// Force Jackson 2.19.2 to be compatible with MCP SDK v0.14.0
-	implementation "com.fasterxml.jackson.core:jackson-core:2.19.2"
-	implementation "com.fasterxml.jackson.core:jackson-databind:2.19.2"
-	implementation "com.fasterxml.jackson.core:jackson-annotations:2.19.2"
+	// Force Jackson 2.20.x to be compatible with MCP SDK v0.17.0
+	implementation "com.fasterxml.jackson.core:jackson-core:2.20.1"
+	implementation "com.fasterxml.jackson.core:jackson-databind:2.20.1"
+	implementation "com.fasterxml.jackson.core:jackson-annotations:2.20"  // 2.20 dropped patch versions
 
 	// Testing dependencies
 	testImplementation "org.mockito:mockito-core:5.21.0"


### PR DESCRIPTION
- jackson-core: 2.19.2 → 2.20.1
- jackson-databind: 2.19.2 → 2.20.1
- jackson-annotations: 2.19.2 → 2.20 (patch versions dropped in 2.20)
- jackson-dataformat-yaml: 2.19.2 → 2.20.1

Consolidates dependency updates from PRs #218, #219, #220. Note: jackson-annotations 2.20.1 doesn't exist - Jackson dropped patch versions for annotations starting with 2.20.

Also updates comments to reflect MCP SDK v0.17.0.