### PR TITLE
Add pyghidra-scripting marketplace skill

### DIFF
--- a/ReVa/skills/pyghidra-scripting/SKILL.md
+++ b/ReVa/skills/pyghidra-scripting/SKILL.md
@@ -1,0 +1,240 @@
+---
+name: pyghidra-scripting
+description: Write and run Python (PyGhidra) code inside the Ghidra session that ReVa's MCP server is already attached to, using the five ReVa scripting tools — `run-script`, `list-scripts`, `read-script`, `write-script`, `edit-script`. Use this whenever the user asks to execute Python against the current program, reach for the Ghidra Flat API directly, write a custom analysis pass, automate something the other ReVa tools don't expose, or persist a `.py` script in Ghidra's scripts directory. Also use when an existing ReVa MCP tool can't do what's needed and the right answer is "drop into PyGhidra for one call." Do NOT use this skill for plain ReVa tool calls that already have a dedicated MCP tool (use that tool instead); do NOT use it to build standalone Python programs that run pyghidra in their own process (the run-script tool runs *inside* the ReVa-hosted Ghidra).
+---
+
+# PyGhidra scripting via ReVa
+
+ReVa exposes five MCP tools under the `scripts` provider that let an assistant write, edit, run, and inspect Python scripts inside the same Ghidra session ReVa is serving. The Python code runs under PyGhidra (CPython 3 + JPype), so it has the full Ghidra Java API available — the `FlatProgramAPI`, `DecompInterface`, `FunctionManager`, everything.
+
+This skill teaches when to reach for these tools, how to structure the Python you send to `run-script`, and the pitfalls that bite in practice.
+
+## The five tools at a glance
+
+| Tool | Purpose | Use when |
+|---|---|---|
+| `run-script` | Execute Python against a program. Inline `code`, or by `scriptPath` / `scriptName`. | The dedicated ReVa MCP tools don't cover what you need, or you want one tight pass over the program. |
+| `list-scripts` | Enumerate scripts across registered directories. Filterable by name/path; paginated. | Discovering what's already saved before writing a new one. |
+| `read-script` | `cat -n` view of a script with `offset` / `limit` and a `truncated` flag. | Reading an existing script before editing it. The numbered output is what `edit-script` lines up against. |
+| `write-script` | Create a new `.py` file (or full overwrite with `overwrite: true`). User-writeable dirs only. | Saving a reusable script. Never reach for this just to bundle inline code — use `run-script` with `code` for one-shot use. |
+| `edit-script` | `old_string` → `new_string` replacement. Errors if `old_string` matches multiple places unless `replace_all: true`. | Iterating on an existing script. Pair with `read-script` to see line context first. |
+
+## Reach-for-it triggers
+
+`run-script` is the escape hatch. Use it when:
+
+- You need to run a custom predicate over every function/symbol/instruction and the existing list/find tools don't filter the right way.
+- You need to combine multiple Ghidra API calls into one operation that would otherwise take many MCP round-trips.
+- You want to use a Ghidra API ReVa doesn't expose — e.g. `DecompInterface` low-level features, `PCode` analysis, custom `AddressSet` arithmetic, the data flow API directly, `BinaryReader`, etc.
+- You're prototyping; once it works and is reusable, save it with `write-script`.
+
+Don't use `run-script` when a dedicated ReVa MCP tool already does the job — those tools have stable schemas and structured output that's easier to reason about than free-form `stdout`. The decompiler / functions / strings / symbols / xrefs tools cover the common path.
+
+## Runtime gate: PyGhidra-only
+
+`run-script` only works when Ghidra was launched **under PyGhidra**:
+
+- ✅ `mcp-reva` (Claude CLI / stdio mode)
+- ✅ `pyghidra-gui` (GUI mode launched with PyGhidra)
+- ✅ `reva_headless_server.py` (headless mode via PyGhidra)
+- ❌ Plain `ghidraRun` — PyGhidra is not wired in; you'll get a `PyGhidraNotAvailableException` error response with launch guidance.
+
+If a `run-script` call comes back with that error, the right move is to tell the user how to relaunch (don't keep retrying). The other four tools (`list-scripts`, `read-script`, `write-script`, `edit-script`) work in every mode because they're plain file operations.
+
+## The execution contract for `run-script`
+
+This is the contract your inline `code` (or saved script) runs under. Internalise it — most failures come from getting one of these wrong.
+
+**Pre-bound globals.** The script runs as a Ghidra PyGhidra script, so the standard `GhidraScript` globals are already defined: `currentProgram`, `currentAddress`, `currentSelection`, `currentHighlight`, `monitor`, `state`, plus `FlatProgramAPI` helpers like `toAddr`, `getFunctionAt`, `getFunctionContaining`, `getSymbolAt`, `getInstructionAt`, `getDataAt`, `getReferencesTo`, `getReferencesFrom`, `createLabel`, `setEOLComment`, `find`, `findBytes`, `clearListing`. You do **not** need to import or set these up. `currentProgram` is the program identified by the `programPath` argument.
+
+**No automatic transaction.** Unlike GhidraScripts run from inside Ghidra's GUI, ReVa's `run-script` deliberately does **not** open a transaction around your code. Any mutation (rename, retype, comment, label, create function, etc.) must be wrapped manually:
+
+```python
+tx = currentProgram.startTransaction("Describe the edit")
+try:
+    # ... do stuff that mutates state ...
+    currentProgram.endTransaction(tx, True)   # commit
+except Exception:
+    currentProgram.endTransaction(tx, False)  # roll back
+    raise
+```
+
+This is intentional — auto-wrapping at the tool layer would create nested-transaction footguns when scripts already handle their own. Read-only scripts (printing, counting, dumping) need no transaction at all.
+
+**Inline header.** When you pass `code`, the tool prepends `# @runtime PyGhidra\n` automatically. Don't add it yourself.
+
+**Cancellation is cooperative.** The configured timeout (default 60s, overridable per-call via `timeoutSeconds`) only fires if your code yields to the monitor. In long loops, call `monitor.isCancelled()` regularly and break:
+
+```python
+fm = currentProgram.getFunctionManager()
+for func in fm.getFunctions(True):
+    if monitor.isCancelled():
+        break
+    # ... work ...
+```
+
+A tight Python loop without a monitor check will run past the timeout. The result will then come back with `timedOut: true` and partial output but the Ghidra session may still be busy for a moment.
+
+**Output is captured and capped.** `stdout` and `stderr` are each capped at 64K chars by default (configurable via `SCRIPT_OUTPUT_CHAR_LIMIT`). If you blow the cap, the result has `stdoutTruncated: true` or `stderrTruncated: true`. Design output for an LLM consumer — terse, structured, line-per-record. Reach for JSON if downstream parsing matters:
+
+```python
+import json
+results = []
+for func in currentProgram.getFunctionManager().getFunctions(True):
+    if monitor.isCancelled(): break
+    if some_predicate(func):
+        results.append({"addr": str(func.getEntryPoint()), "name": func.getName()})
+print(json.dumps(results))
+```
+
+**Result schema.** `run-script` returns:
+
+```json
+{
+  "success": true|false,
+  "programPath": "/binary.exe",
+  "stdout": "...",
+  "stderr": "...",
+  "stdoutTruncated": false,
+  "stderrTruncated": false,
+  "durationMs": 1234,
+  "timedOut": false,
+  "scriptSource": {"type": "inline|path|name", "value": "..."},
+  "error": "ClassName: message"   // only when the executor itself threw
+}
+```
+
+`success` is `false` if the script raised a Python exception (detected via the `Traceback (most recent call last)` marker in stderr), if it hit the timeout, or if the executor threw. Read `stderr` to see the actual traceback — Python exceptions don't surface as MCP errors, they come back in `stderr` with `success: false`.
+
+## What you can call from inside
+
+The script has the full Ghidra/PyGhidra surface. The most commonly useful entry points:
+
+```python
+# Program structure
+prog     = currentProgram                             # the Program object
+listing  = prog.getListing()                          # CodeUnits, data, comments
+memory   = prog.getMemory()                           # blocks, bytes
+fm       = prog.getFunctionManager()                  # functions
+st       = prog.getSymbolTable()                      # symbols/labels
+rm       = prog.getReferenceManager()                 # xrefs
+dtm      = prog.getDataTypeManager()                  # data types
+
+# Flat-API one-liners (already global)
+addr     = toAddr(0x401000)
+func     = getFunctionAt(addr) or getFunctionContaining(addr)
+sym      = getSymbolAt(addr)
+instr    = getInstructionAt(addr)
+xrefs_to = getReferencesTo(addr)
+
+# Java classes — import as normal Python after PyGhidra is up (it is, when run-script runs)
+from ghidra.program.model.symbol import SourceType
+from ghidra.app.decompiler import DecompInterface, DecompileOptions
+```
+
+For everything else: see [references/flat-api.md](references/flat-api.md) for the categorised Flat-API cheat-sheet, and [references/jpype-interop.md](references/jpype-interop.md) for the Java-via-Python idioms (arrays, iterators, sign extension, type stubs).
+
+## Workflow patterns
+
+### Inline one-shot (most common)
+
+```
+run-script(programPath="/bin", code="""
+fm = currentProgram.getFunctionManager()
+total = 0
+huge = []
+for f in fm.getFunctions(True):
+    if monitor.isCancelled(): break
+    size = f.getBody().getNumAddresses()
+    total += size
+    if size > 4096:
+        huge.append((str(f.getEntryPoint()), f.getName(), size))
+print(f'total bytes: {total}')
+for addr, name, size in huge:
+    print(f'{addr} {size:6d} {name}')
+""")
+```
+
+Read the stdout, draw conclusions, move on. Nothing persisted.
+
+### Iterate then save
+
+1. Send a draft via `run-script` with inline `code`.
+2. When it works, call `write-script` with `scriptName="MyAnalysis.py"` and the final `code`. (Pick a descriptive name — `list-scripts` will return it.)
+3. Next time, `run-script` with `scriptName="MyAnalysis.py"`.
+
+### Edit-in-place on a saved script
+
+1. `list-scripts` (or remember the name).
+2. `read-script` — note the line numbers around what you want to change.
+3. `edit-script` with `old_string` set to a *uniquely identifying* slice (include enough surrounding context that there's exactly one match). The tool errors out on ambiguity unless you pass `replace_all: true`.
+4. Re-run via `run-script(scriptName=...)`.
+
+`edit-script` is preferred over re-writing the whole file — it preserves the rest of the script unchanged and is what the user can review as a diff.
+
+## Pitfalls
+
+These are the ones that account for most "why did my script misbehave."
+
+### Forgot the transaction
+Mutations without `startTransaction` throw `IllegalStateException: not in transaction`. If a `run-script` call mutates and you see this in `stderr`, that's the cause. Wrap the mutating block — see the contract section above.
+
+### `monitor.isCancelled()` check missing
+Tight loops that never check the monitor blow past the timeout silently — the `timedOut` flag still flips, but your script may have already done damage. Always check the monitor inside any loop touching every function / instruction / address.
+
+### Java `Iterator` vs Python iterable
+Most Ghidra iterators are Python-iterable thanks to JPype, but a few (notably `SymbolIterator` from some accessors and the older `ReferenceIterator`) only expose `hasNext()` / `next()`. If a `for x in it:` loop silently yields nothing, fall back to `while it.hasNext(): x = it.next()`. `FunctionManager.getFunctions(True)` is iterable directly.
+
+### Java `byte` is signed
+`MemoryBlock.getBytes(addr, byte[] buf)` fills you a Java `byte[]`. Values come back as `-128..127`. Mask with `b & 0xff` if you want `0..255`. Allocating the buffer: `import jpype; buf = jpype.JByte[16]`.
+
+### `print()` is what shows up in stdout
+The script's `print()` is rerouted to the captured stdout writer — that's how you get output back. Don't use logging frameworks expecting them to flush somewhere visible; `print(...)` is the contract.
+
+### Decompiler is expensive to construct
+If you decompile more than a handful of functions in one script, build the `DecompInterface` once and reuse it. Always `dispose()` it. With a per-function timeout of 30s, a 100-function pass that re-builds the decompiler each call can easily blow `run-script`'s overall timeout.
+
+```python
+from ghidra.app.decompiler import DecompInterface
+decomp = DecompInterface()
+decomp.openProgram(currentProgram)
+try:
+    for f in currentProgram.getFunctionManager().getFunctions(True):
+        if monitor.isCancelled(): break
+        res = decomp.decompileFunction(f, 30, monitor)
+        if res.decompileCompleted():
+            # process res.getDecompiledFunction().getC()
+            pass
+finally:
+    decomp.dispose()
+```
+
+### `script` paths must live inside a registered scripts dir
+`run-script(scriptPath=...)` refuses paths outside Ghidra's registered script directories (user dir, system dirs, bundle dirs). Same for `read-script`. For writes, you're additionally limited to the *writeable* set (user dir, typically `~/ghidra_scripts/`). System dirs are read-only.
+
+### Inline `code` and saved scripts both bypass Ghidra's `# @category` UI metadata
+`run-script(code=...)` writes a temp file with only the `# @runtime PyGhidra` header. `# @category`, `# @menupath`, `# @keybinding` headers in a *saved* script matter for the Ghidra GUI but are ignored by `run-script` — keep them if you want the script to appear in the Script Manager, drop them otherwise.
+
+## Where to go next
+
+These reference files are bundled with the skill. Load only the one(s) relevant.
+
+- **[references/flat-api.md](references/flat-api.md)** — Categorised cheat-sheet for the program-inspection surface: `FlatProgramAPI` one-liners (`toAddr`, `getFunctionAt`, `createLabel`, `setEOLComment`, references, comments, bookmarks, search), `AddressSet` arithmetic for restricting iteration, imports/externals/thunks (`isThunk`, `getCallingFunctions`, `ExternalManager`), data types & structs (`StructureDataType`, `DataTypeManager`, `createData`), and `FlatDecompilerAPI` basics. Load when writing inline `code` that inspects or mutates program structure.
+
+- **[references/decompiler-pcode.md](references/decompiler-pcode.md)** — The decompiler's internal representation: `HighFunction`, `LocalSymbolMap`, `HighSymbol`/`HighVariable`/`HighParam`, `Varnode` def-use chains, `PcodeOp` opcodes (COPY/LOAD/CALL/MULTIEQUAL/PTRSUB/…), `ParallelDecompiler` for batch passes, `HighFunctionDBUtil` for persisting decompiler-derived renames. Load when the question is "trace this value back to its source", "where does this argument come from", "which functions look like the decompiler got confused", "rename this `iVar3` to something useful", or any task that needs more than the C source string.
+
+- **[references/jpype-interop.md](references/jpype-interop.md)** — Python ↔ Java boundary notes: arrays (`jpype.JByte[16]`), sign extension, varargs, overload resolution, exception types, getter/setter ↔ property, package collisions, type stubs (`from ghidra.ghidra_builtins import *` under `TYPE_CHECKING`). Load when JPype errors show up or you're doing anything beyond simple `for x in it:` iteration.
+
+- **[references/recipes.md](references/recipes.md)** — Copy-pasteable inline `code` snippets covering the well-trodden paths: function iteration with predicates, xrefs to a symbol with caller context, batch rename by regex, thunks-aware callers of an import, decompile-and-grep, string dump with referencers, call-graph walk, plate/EOL annotations, raw byte reads — plus the heavier patterns: define a struct and apply it to memory, set a function signature with proper storage, trace argN back through Varnode def-use chains, register touches per function, `ParallelDecompiler` batch decompilation, `EmulatorHelper` for string deobfuscation, recursive xref-walking, and persisting a decompiler-derived rename via `HighFunctionDBUtil`. Load when the user asks "how do I do X" and X is a well-trodden path.
+
+- **[references/persistent-scripts.md](references/persistent-scripts.md)** — Conventions for saved scripts: naming, where files land, GhidraScript headers (`# @category`, `# @runtime`), how to discover existing scripts before duplicating, the typical edit cycle. Load when the user wants to save / reuse / iterate on a script rather than one-shot it.
+
+## Working style
+
+A few things that keep PyGhidra-via-ReVa pleasant:
+
+- **Prefer dedicated ReVa tools first.** `run-script` is powerful but free-form; the structured tools (decompiler, functions, strings, xrefs, …) have schemas the assistant can reason about more reliably. Reach for `run-script` only when the structured tools don't cover the question.
+- **Print structured output.** When a `run-script` result is going to be re-consumed by an LLM, prefer JSON or fixed columns over prose. The 64K cap is per-stream — design for it.
+- **Keep transactions narrow.** Open one per logical edit, not one wrapping the whole script. Smaller transactions undo cleanly in Ghidra's history and survive errors better.
+- **Iterate with `edit-script`, not `write-script`.** Once a saved script exists, targeted edits produce reviewable diffs; full overwrites don't.
+- **Read before you edit.** `read-script` first to see the current state and pick `old_string` slices that are unique. Editing blind almost always picks too-short a slice and either misses or hits multiple lines.

--- a/ReVa/skills/pyghidra-scripting/references/decompiler-pcode.md
+++ b/ReVa/skills/pyghidra-scripting/references/decompiler-pcode.md
@@ -1,0 +1,298 @@
+# Decompiler internals: HighFunction, Varnode, PcodeOp
+
+The Flat-API `getDecompiler().decompile(func)` flow gives you back C source as a string. Most of the time that's enough — `decompile-and-grep` is a fine workflow. The next step up is reaching into the decompiler's internal representation:
+
+- **`HighFunction`** — the decompiler's view of a function (variables, basic blocks, PCode in SSA form).
+- **`HighSymbol` / `HighVariable`** — typed, named locals/parameters/globals as the decompiler understands them, plus the storage and definition info that doesn't appear in the raw listing.
+- **`Varnode`** — a single SSA value (a constant, a register read, a memory load, an intermediate). The atomic unit of PCode data flow.
+- **`PcodeOp`** — a single operation (`COPY`, `LOAD`, `CALL`, `INT_ADD`, …). The atomic unit of PCode control flow.
+
+When the LLM is asked "where does this argument come from", "what's the constant fed into this call", "which registers does this function touch as seen by the decompiler", this is the layer to reach for.
+
+## Getting a `HighFunction`
+
+```python
+from ghidra.app.decompiler import DecompInterface, DecompileOptions
+
+decomp = DecompInterface()
+opts = DecompileOptions()
+opts.grabFromProgram(currentProgram)
+decomp.setOptions(opts)
+decomp.openProgram(currentProgram)
+try:
+    res = decomp.decompileFunction(func, 30, monitor)
+    if not res.decompileCompleted():
+        print(f"decompile failed: {res.getErrorMessage()}")
+    else:
+        hf = res.getHighFunction()
+        # hf is a HighFunction — see below
+finally:
+    decomp.dispose()
+```
+
+`HighFunction` is invalidated when the decompiler is disposed. Don't squirrel one away past the `dispose()` call; pull what you need (names, addresses, constants) and let it die.
+
+## `HighFunction` essentials
+
+| Call | Returns | Notes |
+|---|---|---|
+| `hf.getFunction()` | `Function` | The underlying `Function`. |
+| `hf.getLocalSymbolMap()` | `LocalSymbolMap` | Locals, parameters, and globals seen in this function. |
+| `hf.getGlobalSymbolMap()` | `GlobalSymbolMap` | Globals only (subset). |
+| `hf.getPcodeOps()` | `Iterator<PcodeOpAST>` | Every PCode op in the function, in address order. |
+| `hf.getPcodeOps(addr)` | `Iterator<PcodeOpAST>` | PCode ops at a specific address. |
+| `hf.getBasicBlocks()` | `List<PcodeBlockBasic>` | SSA basic blocks. |
+| `hf.getNumVarnodes()` | int | Sanity-check size. |
+
+## `LocalSymbolMap` — looking up variables
+
+```python
+syms = hf.getLocalSymbolMap()
+print(f"params={syms.getNumParams()} locals={syms.getNumLocals()}")
+
+# Iterate all symbols (params + locals + globals seen here)
+it = syms.getSymbols()           # Java Iterator — use hasNext()
+while it.hasNext():
+    sym = it.next()             # HighSymbol
+    hv = sym.getHighVariable()  # HighVariable or None
+    print(f"{sym.getName()}  {sym.getDataType()}  category={sym.getCategoryIndex()}")
+```
+
+`LocalSymbolMap.getSymbols()` returns a Java `Iterator`, not iterable — use `while it.hasNext():`. (One of the few places JPype's auto-conversion doesn't help.)
+
+`HighSymbol` subtypes worth distinguishing:
+- `HighParam` — a parameter; `sym.getSlot()` gives the 0-indexed position.
+- `HighLocal` — a stack local.
+- `HighGlobal` — a global variable referenced in this function.
+- `HighFunctionShellSymbol` — the function itself.
+
+Detecting decompiler-confused symbols (the classic "this analysis is incomplete" smell):
+
+```python
+for sym_name in ["in_", "unaff_", "extraout_"]:
+    bad = []
+    it = syms.getSymbols()
+    while it.hasNext():
+        s = it.next()
+        if s.getName().startswith(sym_name):
+            bad.append(s.getName())
+    if bad:
+        print(f"{sym_name}* symbols ({len(bad)}): {bad[:8]}")
+```
+
+These prefixes mean the decompiler couldn't fully resolve where a value came from — `unaff_*` is a register read of something the function didn't write, `in_*` is an input it couldn't bind to a parameter, `extraout_*` is an extra return value.
+
+## Varnodes
+
+A `Varnode` is one SSA value. The methods that matter:
+
+| Call | Notes |
+|---|---|
+| `v.isConstant()` | True if it's a literal. `v.getOffset()` gives the value. |
+| `v.isRegister()` | True if it represents a CPU register. |
+| `v.isAddress()` | True if it's a memory address. |
+| `v.isUnique()` | True if it's a decompiler-internal temporary. |
+| `v.getAddress()` | The `Address` (for register / memory varnodes). |
+| `v.getSize()` | Byte size. |
+| `v.getDef()` | The `PcodeOp` that produced this varnode (None for inputs). |
+| `v.getDescendants()` | Iterator of `PcodeOp` that consume this varnode. |
+| `v.getHigh()` | The `HighVariable` this varnode belongs to (or None). |
+
+The `getDef()` chain is what you walk **backwards** to answer "where did this value come from." The `getDescendants()` chain is what you walk **forwards** to answer "where does this value go."
+
+## PcodeOps
+
+A `PcodeOp` (or `PcodeOpAST` from a `HighFunction`) is one operation. The methods that matter:
+
+| Call | Notes |
+|---|---|
+| `op.getOpcode()` | A `PcodeOp.*` constant — `COPY`, `LOAD`, `STORE`, `CALL`, `INT_ADD`, `INT_AND`, `INT_ZEXT`, `INT_SEXT`, `CAST`, `MULTIEQUAL`, `PTRSUB`, `PTRADD`, etc. |
+| `op.getMnemonic()` | String form of the opcode. Easier for printing. |
+| `op.getInputs()` / `op.getInput(i)` / `op.getNumInputs()` | Input varnodes. |
+| `op.getOutput()` | Output varnode (or None for `STORE`, `CALL` with no return, etc.). |
+| `op.getSeqnum().getTarget()` | The `Address` this op lives at. |
+| `op.getBasicIter()` | The `PcodeBlockBasic` containing it. |
+
+Common opcodes you'll match on:
+
+```python
+from ghidra.program.model.pcode import PcodeOp
+
+# Direct copy
+PcodeOp.COPY
+
+# Memory access
+PcodeOp.LOAD     # input(1) is the address, input(0) is the address-space id
+PcodeOp.STORE    # input(1) addr, input(2) value
+
+# Calls
+PcodeOp.CALL           # direct, input(0) is callee address (a constant varnode)
+PcodeOp.CALLIND        # indirect, input(0) is a varnode holding the target
+PcodeOp.CALLOTHER      # processor-specific user-op
+
+# Pointer arithmetic (decompiler-synthesised)
+PcodeOp.PTRSUB         # struct/array offset
+PcodeOp.PTRADD         # array index step
+
+# Phi nodes
+PcodeOp.MULTIEQUAL     # SSA join — value depends on which block we came from
+
+# Bit / width manipulation
+PcodeOp.INT_ZEXT       # zero-extend
+PcodeOp.INT_SEXT       # sign-extend
+PcodeOp.CAST           # type cast (no value change)
+PcodeOp.INT_AND        # mask
+PcodeOp.SUBPIECE       # extract a slice
+```
+
+The full set is in `ghidra.program.model.pcode.PcodeOp` — there are ~70 opcodes.
+
+## Backward trace: argument → constant
+
+This pattern shows up everywhere — "what value is passed to argN of this call?"
+
+```python
+def trace_to_constant(vn, max_hops=12):
+    """Walk a Varnode's def-chain backwards, looking for a constant."""
+    seen = set()
+    while vn is not None and max_hops > 0:
+        if vn.isConstant():
+            return vn.getOffset()
+        if vn in seen:
+            return None      # cycle (phi node loop)
+        seen.add(vn)
+        defop = vn.getDef()
+        if defop is None:
+            return None      # function input, no definition in this scope
+        op = defop.getOpcode()
+        if op in (PcodeOp.COPY, PcodeOp.CAST, PcodeOp.INT_ZEXT, PcodeOp.INT_SEXT):
+            vn = defop.getInput(0)            # follow the copy
+        elif op == PcodeOp.INT_AND:
+            # constant mask? collapse if input(1) is a constant
+            a, b = defop.getInput(0), defop.getInput(1)
+            if b.isConstant():
+                vn = a
+            else:
+                return None
+        elif op == PcodeOp.MULTIEQUAL:
+            # SSA phi — only useful if all inputs trace to the same constant
+            vals = {trace_to_constant(i, max_hops - 1) for i in defop.getInputs()}
+            vals.discard(None)
+            return vals.pop() if len(vals) == 1 else None
+        else:
+            return None
+        max_hops -= 1
+    return None
+```
+
+Walk `hf.getPcodeOps()`, find `CALL` ops, pick the input for the argument slot you care about, and feed it to `trace_to_constant`. Argument inputs to `CALL` start at index 1 (`input(0)` is the callee address).
+
+## Forward trace: where does this value get used
+
+```python
+def find_uses(vn, max_hops=4):
+    """Collect PcodeOps that consume vn, recursively, up to max_hops."""
+    out = []
+    frontier = [(vn, 0)]
+    while frontier:
+        cur, depth = frontier.pop()
+        if depth > max_hops: continue
+        for op in cur.getDescendants():
+            out.append(op)
+            if op.getOutput() is not None:
+                frontier.append((op.getOutput(), depth + 1))
+    return out
+```
+
+`getDescendants()` returns an `Iterator<PcodeOp>` and JPype usually makes it iterable; if it doesn't, swap for `while it.hasNext():`.
+
+## ParallelDecompiler: batch-mode
+
+When a script decompiles every function, building one `DecompInterface` per function is wasteful. Ghidra's `ParallelDecompiler` runs decompilation across all CPU cores with a callback per function:
+
+```python
+from ghidra.app.decompiler import DecompInterface, DecompileOptions
+from ghidra.app.decompiler.parallel import (
+    ParallelDecompiler, DecompilerCallback, DecompileConfigurer,
+)
+
+class Configurer(DecompileConfigurer):
+    def configure(self, decompiler):
+        opts = DecompileOptions()
+        opts.grabFromProgram(currentProgram)
+        decompiler.setOptions(opts)
+        decompiler.toggleCCode(True)
+        decompiler.toggleSyntaxTree(True)
+        decompiler.setSimplificationStyle("decompile")
+
+class MyCallback(DecompilerCallback):
+    def __init__(self, prog):
+        super().__init__(prog, Configurer())
+    def process(self, results, monitor):
+        if not results.decompileCompleted():
+            return None
+        hf = results.getHighFunction()
+        # ... analyse hf; return a value you want collected, or None ...
+        return (results.getFunction().getName(), hf.getNumVarnodes())
+
+cb = MyCallback(currentProgram)
+try:
+    funcs = list(currentProgram.getFunctionManager().getFunctions(True))
+    results = ParallelDecompiler.decompileFunctions(cb, funcs, monitor)
+    # `results` is a List of whatever process() returned
+    for r in results or []:
+        if r: print(r)
+finally:
+    cb.dispose()
+```
+
+`ParallelDecompiler.decompileFunctions` is the right call when you'd otherwise decompile more than ~10 functions in a script. The serial form is fine for a handful.
+
+## `HighFunctionDBUtil`: persist decompiler findings
+
+Renames and retypes done via the Flat API (`func.setName(...)`) go straight to the symbol table. Renames done on a *high* symbol (a decompiler-derived local that doesn't have a database backing yet) need `HighFunctionDBUtil`:
+
+```python
+from ghidra.program.model.pcode import HighFunctionDBUtil
+from ghidra.program.model.symbol import SourceType
+
+# Find the HighSymbol you want to rename
+it = hf.getLocalSymbolMap().getSymbols()
+while it.hasNext():
+    sym = it.next()
+    if sym.getName() == "iVar2":
+        tx = currentProgram.startTransaction("Rename iVar2")
+        try:
+            HighFunctionDBUtil.updateDBVariable(
+                sym, "loop_counter", None, SourceType.USER_DEFINED)
+            currentProgram.endTransaction(tx, True)
+        except Exception:
+            currentProgram.endTransaction(tx, False)
+            raise
+        break
+```
+
+Pass `None` for the data type to keep the current type and only rename. Pass a `DataType` to change both.
+
+For function signatures, the related helpers are `HighFunctionDBUtil.commitParamsToDatabase(hf, useDataTypes, sourceType)` and `commitReturnToDatabase(hf, sourceType)`. These take everything the decompiler inferred for parameters / return type and write it back permanently — useful after running data-flow analysis that improved signatures.
+
+## Clang AST: the rendered C tree
+
+The C source you get from `res.getDecompiledFunction().getC()` is the rendered form of a `ClangTokenGroup` tree. Walking that tree (`ClangNode`, `ClangStatement`, `ClangToken`) lets you map between source positions and PCode ops:
+
+```python
+ccode = res.getCCodeMarkup()    # ClangTokenGroup
+# ccode.numChildren(), ccode.Child(i), token.getPcodeOp(), token.getHighVariable()
+```
+
+This is niche — most analyses are fine with the string form or pure PCode. Reach for the Clang AST when you need "what's the C statement at offset X" or "which token corresponds to varnode V".
+
+## Pitfalls specific to this layer
+
+- **`HighFunction` is invalidated by `decomp.dispose()`.** Pull everything you need before disposing.
+- **`LocalSymbolMap.getSymbols()` is a Java `Iterator`,** not iterable. Use `while it.hasNext():`.
+- **`Varnode` equality is reference identity,** not value identity. Two varnodes representing the same SSA value compare unequal if they're separate objects. Use `id(v)` if you need a hashable key, or compare `(v.getAddress(), v.getSize(), v.getDef())`.
+- **`MULTIEQUAL` (phi) nodes cycle.** Always track visited varnodes when walking `getDef()` chains.
+- **`getDescendants()` only sees ops *inside the same function*.** Cross-function data flow needs you to find the corresponding `Varnode` in the callee's `HighFunction` (typically the parameter at the matching slot).
+- **Address-space ids in `LOAD`/`STORE`.** `input(0)` is a constant varnode whose offset is the address-space id, not an address. The actual address is `input(1)`.
+- **PCode ops from `hf.getPcodeOps()` are `PcodeOpAST`,** a subclass of `PcodeOp` that also knows its parent basic block (`op.getParent()`). They're returned in address order but the SSA structure is what matters.

--- a/ReVa/skills/pyghidra-scripting/references/flat-api.md
+++ b/ReVa/skills/pyghidra-scripting/references/flat-api.md
@@ -1,0 +1,292 @@
+# Ghidra Flat API cheat-sheet
+
+Reference for the `FlatProgramAPI` + `FlatDecompilerAPI` + `GhidraScript` surface that's pre-bound when `run-script` executes your `code`. Methods listed here are available as bare names (e.g. `toAddr(...)`, `getFunctionAt(...)`) — no import needed.
+
+For the underlying managers (`FunctionManager`, `SymbolTable`, `Listing`, `ReferenceManager`, `Memory`, `DataTypeManager`) reach through `currentProgram.getFunctionManager()` etc. — those have richer APIs when the Flat helpers don't fit.
+
+## Program & memory
+
+| Call | Returns | Notes |
+|---|---|---|
+| `currentProgram` | `Program` | The program identified by the tool's `programPath` argument. |
+| `getMemoryBlock(addr)` / `getMemoryBlock(name)` | `MemoryBlock` or `None` | By address or by section name (`.text`, `.rodata`, …). |
+| `currentProgram.getMemory().getBlocks()` | `MemoryBlock[]` | All blocks, in order. |
+| `block.getBytes(start, byte[] buf)` | int (count read) | `buf` is a Java `byte[]`; allocate via `jpype.JByte[N]`. |
+| `block.getStart()` / `block.getEnd()` / `block.getSize()` | `Address` / long | Bounds. |
+| `currentProgram.getImageBase()` | `Address` | For relocatables / address math. |
+
+## Addresses
+
+| Call | Notes |
+|---|---|
+| `toAddr(0x401000)` / `toAddr("0x401000")` | The primary way to construct an `Address`. |
+| `currentAddress` | The current selection's address (often `None` under `run-script`). |
+| `addr.add(n)` / `addr.subtract(n)` | Returns a new `Address`. |
+| `addr.getOffset()` | `long` (the numeric value). |
+| `currentProgram.getAddressFactory().getAddress("0x401000")` | When `toAddr` won't parse. |
+
+## Address sets
+
+When iterating instructions / data / functions, restricting to an `AddressSet` saves a lot of time on large programs and lets you express "only inside this function", "only in `.text`", "only in the .data region between X and Y."
+
+```python
+from ghidra.program.model.address import AddressSet
+
+# Whole program (default)
+listing.getInstructions(True)
+
+# Restricted to a function body
+listing.getInstructions(func.getBody(), True)        # AddressSetView
+
+# Just the .text block
+text = currentProgram.getMemory().getBlock(".text")
+text_set = AddressSet(text.getStart(), text.getEnd())
+listing.getInstructions(text_set, True)
+
+# All executable memory (handy: getExecuteSet picks every block with X permission)
+exec_set = currentProgram.getMemory().getExecuteSet()
+listing.getInstructions(exec_set, True)
+```
+
+Set arithmetic: `set.add(otherSet)`, `set.subtract(otherSet)`, `set.intersect(otherSet)`. `AddressSet(start, end)` builds a single-range set; the union of ranges is built up with `.add()`.
+
+`AddressSetView` is the read-only interface most APIs accept; `AddressSet` is the mutable subclass. `func.getBody()` returns an `AddressSetView` (the function's address ranges, which can be discontiguous for thunks and tail-merged code).
+
+## Functions
+
+| Call | Returns | Notes |
+|---|---|---|
+| `getFunctionAt(addr)` | `Function` or `None` | Exact entry point. |
+| `getFunctionContaining(addr)` | `Function` or `None` | Anywhere inside the body. |
+| `getFunctionBefore(addr)` / `getFunctionAfter(addr)` | `Function` | Iteration helpers. |
+| `getFirstFunction()` / `getLastFunction()` | `Function` | Start/end. |
+| `getFunction("name")` | `Function` or `None` | First match by name; ambiguous in stripped binaries. |
+| `getGlobalFunctions("name")` | `List<Function>` | All functions matching name (handles namespaces). |
+| `currentProgram.getFunctionManager().getFunctions(True)` | iterable | Forward iteration over all functions. |
+| `createFunction(entryAddr, "name")` | `Function` | **Needs transaction.** Won't replace an existing function. |
+| `removeFunction(func)` / `removeFunctionAt(addr)` | `bool` | **Needs transaction.** |
+| `func.getEntryPoint()` | `Address` | |
+| `func.getBody()` | `AddressSetView` | All addresses owned by the function. |
+| `func.getParameters()` | `Parameter[]` | |
+| `func.getAllVariables()` | `Variable[]` | Locals + params. |
+| `func.setName("name", SourceType.USER_DEFINED)` | | **Needs transaction.** Import `SourceType` from `ghidra.program.model.symbol`. |
+| `func.setReturnType(dt, SourceType.USER_DEFINED)` | | |
+
+## Symbols & labels
+
+| Call | Returns | Notes |
+|---|---|---|
+| `getSymbolAt(addr)` | `Symbol` or `None` | Primary symbol. |
+| `getSymbolAt(addr, "name")` | `Symbol` | Disambiguates when multiple symbols share an address. |
+| `getSymbol("name", namespace)` | `Symbol` or `None` | `None` namespace = global. |
+| `getSymbols("name", namespace)` | `List<Symbol>` | All matches. |
+| `getSymbolBefore(addr)` / `getSymbolAfter(addr)` | `Symbol` | Linear traversal. |
+| `createLabel(addr, "name", makePrimary)` | `Symbol` | **Needs transaction.** |
+| `createLabel(addr, "name", namespace, makePrimary)` | `Symbol` | Namespaced. |
+| `removeSymbol(addr, "name")` | `bool` | **Needs transaction.** |
+| `currentProgram.getSymbolTable().getAllSymbols(True)` | iterable | All symbols, including dynamic. |
+
+`SourceType` import: `from ghidra.program.model.symbol import SourceType` — values: `USER_DEFINED`, `IMPORTED`, `ANALYSIS`, `DEFAULT`.
+
+## Imports, externals & thunks
+
+PE/ELF binaries link to library functions through an indirection: a small "thunk" function in the binary jumps to an external symbol that the loader resolves. So when you look for "callers of `WinExec`", direct xrefs to the external symbol find the thunk, not the real users — you have to walk back through the thunk.
+
+| Call | Returns | Notes |
+|---|---|---|
+| `currentProgram.getExternalManager()` | `ExternalManager` | Entry point for external libraries / functions. |
+| `extMgr.getExternalLibraryNames()` | `String[]` | "KERNEL32.DLL", "ucrtbase.dll", … |
+| `extMgr.getExternalLocations(libName)` | `Iterator<ExternalLocation>` | Functions/data imported from one library. |
+| `extMgr.getExternalLocation(symbol)` | `ExternalLocation` | The external binding for an external symbol. |
+| `currentProgram.getSymbolTable().getExternalSymbols()` | iterable | All external symbols (across libraries). |
+| `func.isThunk()` | bool | True if this function is just a jump/trampoline. |
+| `func.getThunkedFunction(recurse)` | `Function` | The real underlying function. `recurse=True` chases through chains. |
+| `func.getFunctionThunkAddresses()` | `Address[]` | Addresses of thunks pointing at this function (works on both real and external). |
+| `func.getCallingFunctions(monitor)` | `Set<Function>` | All functions that call this one — *automatically walks through thunks*. |
+| `func.getCalledFunctions(monitor)` | `Set<Function>` | Functions called from this one — likewise transparent to thunks. |
+
+The shortest path to "who calls `WinExec` for real" is: get the `Function` for `WinExec`, call `getCallingFunctions(monitor)`. Ghidra resolves thunks for you. The xrefs-to-symbol approach only works correctly if you then `getThunkedFunction()` and chase callers of each thunk.
+
+## Instructions & data
+
+| Call | Returns | Notes |
+|---|---|---|
+| `getInstructionAt(addr)` | `Instruction` or `None` | Exact start. |
+| `getInstructionContaining(addr)` | `Instruction` or `None` | Anywhere inside. |
+| `getInstructionBefore(addr)` / `getInstructionAfter(addr)` | `Instruction` | |
+| `getFirstInstruction()` / `getLastInstruction()` | `Instruction` | |
+| `getDataAt(addr)` / `getDataContaining(addr)` | `Data` or `None` | |
+| `getDataBefore(addr)` / `getDataAfter(addr)` | `Data` | |
+| `getUndefinedDataAt(addr)` / `getUndefinedDataBefore(addr)` / `getUndefinedDataAfter(addr)` | `Data` | Find gaps. |
+| `createData(addr, dt)` | `Data` | **Needs transaction.** Clears existing. |
+| `createByte(addr)` / `createWord(addr)` / `createDWord(addr)` / `createQWord(addr)` | `Data` | Primitive shortcuts. |
+| `createAsciiString(addr)` / `createUnicodeString(addr)` | `Data` | |
+| `removeData(data)` / `removeDataAt(addr)` | `bool` | **Needs transaction.** |
+| `removeInstruction(instr)` / `removeInstructionAt(addr)` | `bool` | **Needs transaction.** |
+| `clearListing(addr)` / `clearListing(start, end)` | | **Needs transaction.** Various overloads for code/data/refs/symbols. |
+| `disassemble(addr)` | `bool` | Force disassembly. Auto-analysis usually handles this. |
+| `instr.getMnemonicString()` / `instr.getOperand(i)` / `instr.getOpObjects(i)` | | Inspect operands. |
+| `instr.getFlowType()` | `FlowType` | `isCall()`, `isJump()`, `isFallthrough()`. |
+| `data.getValue()` / `data.getBytes()` / `data.getDataType()` | | |
+
+## Data types & structs
+
+Defining a struct and applying it to memory is one of the higher-leverage moves in Ghidra — once a region of bytes is typed, the listing shows fields by name and the decompiler propagates types automatically.
+
+| Call | Returns | Notes |
+|---|---|---|
+| `currentProgram.getDataTypeManager()` | `DataTypeManager` | Per-program type DB. |
+| `dtm.getDataType("/MyCategory/MyStruct")` | `DataType` or `None` | Lookup by path. |
+| `dtm.findDataType("MyStruct")` | `DataType` | Lookup without category. |
+| `dtm.addDataType(dt, conflictHandler)` | `DataType` | Register a new type. **Needs transaction.** |
+| `dtm.getAllDataTypes()` | `Iterator<DataType>` | All types in this program's DB. |
+| `BuiltInDataTypeManager.getDataTypeManager()` | `DataTypeManager` | The cross-program built-in types. |
+| `DataTypeParserUtil.parseDataTypeObjectFromString(dtm, "char *")` | `DataType` | ReVa's util — handles strings like `int[10]`, `MyStruct *`, `void`. Already in this codebase; import from `reva.util`. |
+| `StructureDataType(name, size)` | new `Structure` | Build from code. `size=0` = auto-grow. |
+| `struct.add(componentType, "fieldName", "comment")` | | Append a field. **Needs transaction** once the struct is in a DTM. |
+| `struct.insertAtOffset(off, type, len, "name", "comment")` | | Place a field at a specific offset. |
+| `createData(addr, dt)` | `Data` | Apply a type at an address. **Needs transaction.** Clears existing data. |
+
+Building a struct from scratch:
+
+```python
+from ghidra.program.model.data import StructureDataType, IntegerDataType, PointerDataType, CharDataType
+from ghidra.program.model.data import DataTypeConflictHandler
+
+dtm = currentProgram.getDataTypeManager()
+s = StructureDataType("MyHeader", 0)        # 0 = auto-grow
+s.add(IntegerDataType(),  "magic",   "Signature")
+s.add(IntegerDataType(),  "version", None)
+s.add(PointerDataType(CharDataType()), "name", None)
+
+tx = currentProgram.startTransaction("Define MyHeader")
+try:
+    s = dtm.addDataType(s, DataTypeConflictHandler.DEFAULT_HANDLER)
+    createData(toAddr(0x404000), s)
+    currentProgram.endTransaction(tx, True)
+except Exception:
+    currentProgram.endTransaction(tx, False)
+    raise
+```
+
+For composite types: `StructureDataType`, `UnionDataType`, `EnumDataType(name, size)` (then `.add("CONST_NAME", value)`), `ArrayDataType(elementType, count, elementSize)`, `TypedefDataType("Alias", underlying)`, `FunctionDefinitionDataType("name")`.
+
+When you have a type string from the user (`"int"`, `"MyStruct *"`, `"char[16]"`), use `DataTypeParserUtil` — parsing the string into the right `DataType` by hand is fiddly:
+
+```python
+from reva.util import DataTypeParserUtil
+dt = DataTypeParserUtil.parseDataTypeObjectFromString(dtm, "MyHeader *")
+```
+
+`getDataTypeManager()` returns the program's type DB; type IDs and references are stable within that DB but not across programs. Imported headers go into category paths (`/MyHeader.h/MyStruct`); user-defined types default to `/`.
+
+## References / xrefs
+
+| Call | Returns | Notes |
+|---|---|---|
+| `getReferencesTo(addr)` | `Reference[]` | All xrefs pointing at `addr`. Large on hot functions. |
+| `getReferencesFrom(addr)` | `Reference[]` | All refs originating at `addr`. Check `getOperandIndex()` to disambiguate per-operand. |
+| `getReference(instr_or_data, toAddr)` | `Reference` or `None` | Specific edge. |
+| `createMemoryReference(instr, opIndex, toAddr, refType, sourceType)` | `Reference` | **Needs transaction.** |
+| `removeReference(ref)` | | **Needs transaction.** |
+| `ref.getFromAddress()` / `ref.getToAddress()` / `ref.getReferenceType()` | | |
+
+`RefType` import: `from ghidra.program.model.symbol import RefType` — `READ`, `WRITE`, `DATA`, `COMPUTED_CALL`, `UNCONDITIONAL_CALL`, `UNCONDITIONAL_JUMP`, `FALL_THROUGH`, …
+
+## Comments
+
+| Call | Notes |
+|---|---|
+| `setPlateComment(addr, "text")` | Block above the listing item. |
+| `setPreComment(addr, "text")` | |
+| `setPostComment(addr, "text")` | |
+| `setEOLComment(addr, "text")` | End-of-line. |
+| `setRepeatableComment(addr, "text")` | Propagates to all xref sites. |
+| `getPlateComment(addr)` / `getPreComment(addr)` / `getPostComment(addr)` / `getEOLComment(addr)` / `getRepeatableComment(addr)` | Returns `str` or `None`. |
+
+All setters need a transaction. Pass `None` (or `""`) to clear.
+
+## Bookmarks
+
+| Call | Notes |
+|---|---|
+| `createBookmark(addr, "Category", "note")` | `Bookmark`. **Needs transaction.** |
+| `currentProgram.getBookmarkManager().getBookmarksIterator(category)` | Iterate by category. |
+| `removeBookmark(bookmark)` | **Needs transaction.** |
+
+## Search
+
+| Call | Notes |
+|---|---|
+| `find(startAddr, byteValue)` | First match address, or `None`. |
+| `find(startAddr, byte[])` | Sequence search. |
+| `findBytes(startAddr, "FF ?? FF", limit, forward)` | Regex-ish wildcards (`??` = any byte). |
+| `findBytes(addressSet, "...", limit)` | Restricted to a set. |
+| `find("string")` | Substring search in raw bytes. |
+| `findStrings(addressSet, minLength, alignment, requireNull, allCharSets)` | Auto-detect strings; returns `FoundString` iterator. |
+
+## Decompiler
+
+`FlatDecompilerAPI` is high-level and convenient; for batch work or fine control, drop to `DecompInterface` directly.
+
+```python
+# High-level (one-off, simple)
+from ghidra.app.decompiler.flatapi import FlatDecompilerAPI
+flat = FlatDecompilerAPI()           # uses currentProgram via state
+flat.initialize()
+try:
+    c_source = flat.decompile(func, 30)   # 30-sec timeout per function
+finally:
+    flat.dispose()
+
+# Low-level (batch, preferred when decompiling many functions)
+from ghidra.app.decompiler import DecompInterface
+decomp = DecompInterface()
+decomp.openProgram(currentProgram)
+try:
+    for func in currentProgram.getFunctionManager().getFunctions(True):
+        if monitor.isCancelled(): break
+        res = decomp.decompileFunction(func, 30, monitor)
+        if res.decompileCompleted():
+            c_source = res.getDecompiledFunction().getC()
+            high_func = res.getHighFunction()
+            # ... process ...
+finally:
+    decomp.dispose()
+```
+
+`dispose()` is mandatory — it tears down a native subprocess. Skipping it leaks.
+
+For variable renames that persist in the database, use `HighFunctionDBUtil.updateDBVariable(highSymbol, name, dt, SourceType.USER_DEFINED)` from inside a transaction (`from ghidra.program.model.pcode import HighFunctionDBUtil`).
+
+## User interaction
+
+`askString`, `askFile`, `askYesNo`, `popup`, `println`, etc. exist as `GhidraScript` globals but are useless under `run-script` (no human at the keyboard — they'll return defaults, throw, or hang). Use `print()` and hard-coded values from the tool's `code` argument instead.
+
+## Monitor (timeout cooperation)
+
+| Call | Notes |
+|---|---|
+| `monitor.isCancelled()` | Soft check; safe in cleanup paths. |
+| `monitor.checkCancelled()` | Throws `CancelledException` if cancelled. Let it propagate. |
+| `monitor.setMessage("text")` | UI feedback (visible in GUI mode). |
+| `monitor.setProgress(n)` / `monitor.setMaximum(n)` | Progress bar updates. |
+
+Forgetting to check the monitor inside long loops is the #1 reason a `run-script` call ignores its timeout. Add a check at the top of any per-function/per-instruction loop.
+
+## Transaction pattern
+
+```python
+tx = currentProgram.startTransaction("Rename trivial wrappers")
+try:
+    for f in currentProgram.getFunctionManager().getFunctions(True):
+        if monitor.isCancelled(): break
+        if f.getBody().getNumAddresses() < 8:
+            f.setName(f"wrapper_{f.getEntryPoint()}", SourceType.USER_DEFINED)
+    currentProgram.endTransaction(tx, True)
+except Exception:
+    currentProgram.endTransaction(tx, False)
+    raise
+```
+
+Always pair `start` with `end`. Commit on success (`True`); roll back on failure (`False`). Don't nest transactions on the same program — `pyghidra.analyze()` and some auto-analyzers manage their own and dislike re-entry.

--- a/ReVa/skills/pyghidra-scripting/references/jpype-interop.md
+++ b/ReVa/skills/pyghidra-scripting/references/jpype-interop.md
@@ -1,0 +1,207 @@
+# JPype / Python ↔ Java interop notes
+
+PyGhidra exposes Ghidra's Java API to CPython via JPype. Most of the time it Just Works — Java getters look like Python properties, Java iterables look iterable, `str` ↔ `String` is transparent. The notes below are the edge cases that bite when they bite.
+
+## Importing Ghidra classes inside `run-script`
+
+The JVM is already up when your `run-script` code runs, so you can import Ghidra packages directly at the top of the script:
+
+```python
+from ghidra.program.model.symbol import SourceType, RefType
+from ghidra.app.decompiler import DecompInterface
+from ghidra.program.model.address import AddressSet
+from ghidra.program.model.pcode import HighFunctionDBUtil
+from java.util import HashSet, ArrayList
+```
+
+No `pyghidra.start()` is needed — that's already happened. Don't include it; it's a no-op at best and noise at worst.
+
+## Getter ↔ property
+
+JPype exposes Java `getFoo()` / `setFoo(v)` as a `foo` property *and* keeps the explicit form. Both work:
+
+```python
+func.name              # → calls getName()
+func.getName()         # equivalent
+func.name = "decoded"  # → calls setName("decoded", SourceType.USER_DEFINED)? NO — see below
+```
+
+The property form is only available for single-arg setters. `Function.setName(String, SourceType)` takes two args, so `func.name = "x"` doesn't compile — use `func.setName("x", SourceType.USER_DEFINED)` explicitly. When in doubt, use the explicit form; it never surprises.
+
+## Java arrays
+
+Several Ghidra methods need a Java array — typically a `byte[]` buffer:
+
+```python
+import jpype
+
+# Allocate a 16-byte Java byte[]
+buf = jpype.JByte[16]
+
+block = currentProgram.getMemory().getBlock(".text")
+block.getBytes(block.getStart(), buf)   # fills in-place
+```
+
+Going the other way (Python bytes → Java byte[]) is automatic for parameters that won't be mutated. If you hit "no matching overload," wrap explicitly:
+
+```python
+my_bytes = jpype.JArray(jpype.JByte)(b"\x00\x01\x02")
+```
+
+Other element types: `jpype.JInt[8]`, `jpype.JLong[4]`, `jpype.JChar[16]`. Multi-dimensional: `jpype.JInt[3][3]`.
+
+## Java `byte` is signed
+
+`byte` in Java is `-128..127`. When you read from a `byte[]`, negative values come back:
+
+```python
+for b in buf:
+    print(hex(b & 0xff))   # mask to 0..255 for display
+```
+
+If you want a Python `bytes` object, the safest conversion is:
+
+```python
+data = bytes(b & 0xff for b in buf)
+```
+
+Don't trust `bytes(buf)` to do the right thing on all JPype versions.
+
+## Iterators
+
+Most Ghidra iterators are Python-iterable thanks to JPype's automatic conversion:
+
+```python
+for func in currentProgram.getFunctionManager().getFunctions(True):
+    ...
+
+for block in currentProgram.getMemory().getBlocks():
+    ...
+```
+
+A few aren't — historically the `SymbolIterator` from some accessors and the older `ReferenceIterator` were `Iterator`-only. When `for x in it:` silently yields nothing, fall back:
+
+```python
+it = some_call_returning_iterator()
+while it.hasNext():
+    item = it.next()
+    ...
+```
+
+When uncertain, `while hasNext()` always works. `Iterable` collections (`getAllVariables()`, `getReferencesTo()`, etc. that return `[]` or `List`) are iterable directly.
+
+## Java collections
+
+`java.util.List`, `Set`, `Map` are iterable and indexable like their Python equivalents thanks to JPype customisations:
+
+```python
+from java.util import ArrayList
+xs = ArrayList()
+xs.add("a"); xs.add("b")
+print(xs[0])           # "a"
+print(list(xs))        # ['a', 'b']
+print(len(xs))         # 2
+```
+
+For dict-like access, `Map` supports both `m.get(k)` (Java) and `m[k]` (Python). Iteration yields keys.
+
+## Overload resolution
+
+JPype picks the best matching overload based on Python types. Ambiguous cases (e.g., passing `None` where the parameter is `Object` and there's another `String` overload) can resolve unexpectedly. Force a specific type with a cast:
+
+```python
+import jpype
+from java.lang import String
+flat.something(jpype.JObject(None, String))   # explicit null String
+```
+
+For numeric args, `int` may match either `int` or `long` overloads; if you hit "ambiguous," wrap with `jpype.JInt(x)` or `jpype.JLong(x)`.
+
+## Exceptions
+
+Java exceptions surface as Python exceptions inheriting from `jpype.JException`. Catch them by Java class:
+
+```python
+from ghidra.util.exception import CancelledException
+
+try:
+    monitor.checkCancelled()
+    big_work()
+except CancelledException:
+    print("user cancelled")
+```
+
+`Exception` from `java.lang.Exception` doesn't catch *every* Java exception (some inherit `Throwable` directly). For broadest catch, use `jpype.JException` or just `BaseException` — but only for cleanup, never as control flow.
+
+## `print()` and stdout
+
+In `run-script`, `print()` is rerouted to the captured stdout writer. Anything you `print` shows up in the result's `stdout` field, capped at the configured output limit. `sys.stdout.write(...)` works too; `logging` doesn't unless you configure a handler explicitly — usually not worth it.
+
+For binary output back to the caller, base64-encode and print:
+
+```python
+import base64
+print(base64.b64encode(bytes(b & 0xff for b in buf)).decode())
+```
+
+## Package-name collisions
+
+When a Java package name collides with a Python stdlib module (the canonical example: `pdb` is both Python's debugger and Ghidra's PDB importer), the Java side is available with a trailing underscore — `import pdb_` to get Ghidra's. Rare in practice.
+
+## Type stubs for editor autocomplete
+
+When *authoring* scripts in an editor (rather than letting the LLM emit code blind), install Ghidra's type stubs to get full IDE autocomplete:
+
+```
+pip install ghidra-stubs==<your-ghidra-version>
+```
+
+Then in the script, gate the import so it doesn't run at script execution:
+
+```python
+import typing
+if typing.TYPE_CHECKING:
+    from ghidra.ghidra_builtins import *      # currentProgram, toAddr, monitor, ...
+    from ghidra.program.model.listing import Program, Function
+```
+
+`TYPE_CHECKING` is `False` at runtime so the import is never executed (no JVM bootstrap needed at import time). At type-check time it's `True` and your editor sees all the symbols.
+
+This matters for human-written scripts; for the LLM emitting `run-script` code, skip it — the globals are already bound and you don't get autocomplete benefit from a string.
+
+## `state` and `currentHighlight` etc.
+
+The PyGhidra GhidraScript runtime binds these globals:
+
+| Global | What it is |
+|---|---|
+| `currentProgram` | `Program` — the program identified by `programPath` |
+| `currentAddress` | `Address` or `None` — usually `None` under `run-script` |
+| `currentSelection` | `ProgramSelection` or `None` — usually `None` |
+| `currentHighlight` | `ProgramSelection` or `None` — usually `None` |
+| `monitor` | `TaskMonitor` — your cancellation/timeout signal |
+| `state` | `GhidraState` — full script execution context |
+| `__this__` / `this` | the underlying `GhidraScript` instance |
+
+Under `run-script`, `currentAddress` / `currentSelection` / `currentHighlight` are almost always `None` because there's no human cursor. Don't write logic that depends on them — take the address you want as a tool argument and use `toAddr(...)` instead. (`run-script` itself doesn't have an `address` arg, so this typically means hard-coding addresses into the inline `code`, or passing them through to a *saved* script via `scriptName` + custom logic.)
+
+## Useful one-liners
+
+```python
+# bytes from memory, as a Python bytes
+import jpype
+buf = jpype.JByte[16]; block.getBytes(addr, buf)
+data = bytes(b & 0xff for b in buf)
+
+# Java HashSet of addresses
+from java.util import HashSet
+seen = HashSet()
+seen.add(addr)
+if seen.contains(other_addr): ...
+
+# convert a Java List to Python list
+py_list = list(java_list)
+
+# format an Address consistently
+"0x" + str(addr)        # matches ReVa's AddressUtil.formatAddress() output
+```

--- a/ReVa/skills/pyghidra-scripting/references/persistent-scripts.md
+++ b/ReVa/skills/pyghidra-scripting/references/persistent-scripts.md
@@ -1,0 +1,123 @@
+# Saved scripts: list / read / write / edit
+
+This file covers the workflow for scripts that live as `.py` files on disk under Ghidra's registered script directories, rather than as inline `code` to `run-script`. The four file-management tools (`list-scripts`, `read-script`, `write-script`, `edit-script`) work in every ReVa mode, even when PyGhidra isn't wired up — only `run-script` itself needs the PyGhidra runtime.
+
+## When to save vs. one-shot
+
+Inline `code` is right when the work is exploratory, one-off, or you're still iterating. Save with `write-script` when:
+
+- The same logic will be re-run (different binaries, different days).
+- The user explicitly asks for "a script that does X."
+- The script crossed ~50 lines or has comments worth keeping.
+- You want it to appear in Ghidra's Script Manager (GUI mode).
+
+Don't save partial drafts — get it working inline first, then save the finished version.
+
+## Where scripts live
+
+Scripts live in registered directories. `list-scripts` enumerates all of them. Common ones:
+
+- `~/ghidra_scripts/` — the **user dir**. Writeable. This is where `write-script` puts new files when you pass `scriptName` instead of an absolute `scriptPath`.
+- `<Ghidra install>/Ghidra/Features/.../ghidra_scripts/` — bundled system scripts. **Read-only.** `write-script` / `edit-script` will refuse paths here.
+- Bundle script dirs configured in the Ghidra Bundle Manager — usually read-only.
+- ReVa's own `ghidra_scripts/` directory (shipped with the extension) — sample scripts; read-only.
+
+`list-scripts` returns each entry with a `writeable` boolean so you can tell at a glance which directory it's in.
+
+## Naming conventions
+
+- End in `.py`. The tool doesn't enforce it but Ghidra discovery does.
+- CamelCase or snake_case both work; the existing Ghidra examples use CamelCase (`AnalyzeStuff.py`, `FindCryptoConsts.py`).
+- Avoid generic names like `script.py` or `test.py` — they collide and they don't tell `list-scripts` consumers anything.
+- Prefix with the analysis target if appropriate: `wallaby_dump_strings.py`, `loader_decrypt_strings.py`.
+
+## GhidraScript headers
+
+Saved scripts can carry headers Ghidra reads for the Script Manager UI:
+
+```python
+# Some short one-line description here.
+# @category Analysis.MyCategory
+# @runtime PyGhidra
+# @menupath Tools.Reverse.MyAnalysis
+# @keybinding ctrl shift M
+# @toolbar
+```
+
+| Header | What it does |
+|---|---|
+| `# @runtime PyGhidra` | **Required** for CPython 3 execution. Without it, Ghidra tries Jython and you get import errors. |
+| `# @category Foo.Bar` | Where it shows up in the GUI Script Manager tree. Dots → submenus. |
+| `# @menupath Tools.X.Y` | Top-menu placement. |
+| `# @keybinding ctrl shift M` | Hotkey. |
+| `# @toolbar` | Toolbar icon (with a matching `.gif`/`.png`). |
+| The first comment line | One-line description shown in the Script Manager. |
+
+`run-script` honours `# @runtime PyGhidra` and ignores the rest. When you `write-script` something you intend to use *only* via `run-script` from the LLM, the other headers are optional.
+
+ReVa's `run-script(code=...)` mode adds `# @runtime PyGhidra` to inline temp files automatically — but it does **not** when you `write-script` a saved file. If you save a script and later it fails to run because Ghidra tries Jython, the missing header is the cause.
+
+## The typical workflow
+
+### First time
+
+```
+1. list-scripts(nameFilter="String")                # see if something exists
+2. run-script(programPath="/bin", code="""...""")   # prototype inline
+3. iterate inline until it works
+4. write-script(scriptName="DumpStringsWithXrefs.py", code="""
+   # Dump all defined strings with their callers.
+   # @runtime PyGhidra
+   # @category Analysis
+   ...final code...
+   """)
+5. run-script(programPath="/bin", scriptName="DumpStringsWithXrefs.py")
+```
+
+### Iterating on a saved script
+
+```
+1. read-script(scriptName="DumpStringsWithXrefs.py")
+   # Note the cat -n line numbers around what you want to change.
+2. edit-script(
+     scriptName="DumpStringsWithXrefs.py",
+     old_string="    if not refs: continue",
+     new_string="    # require at least 2 referencers\n    if len(refs) < 2: continue",
+   )
+3. run-script(scriptName="DumpStringsWithXrefs.py")
+```
+
+Why not `write-script(overwrite=true)`? Because `edit-script` produces a clean diff and only touches the lines you changed; full overwrites obscure intent and risk losing concurrent edits.
+
+## Picking a good `old_string` for `edit-script`
+
+`edit-script` errors when `old_string` matches zero or multiple locations (unless `replace_all: true`). To make a match unique, include surrounding context:
+
+**Bad** (likely matches several places):
+```python
+old_string="    if not refs: continue"
+```
+
+**Good** (anchored by the comment two lines above):
+```python
+old_string="""    refs = [r for r in getReferencesTo(addr) if getFunctionContaining(r.getFromAddress())]
+    if not refs: continue"""
+```
+
+Read the file with `read-script` first, find a chunk that's clearly unique (often the line plus 1-2 above and below), and use that.
+
+`replace_all: true` is right when you're doing a name change that *should* hit every occurrence — renaming a variable throughout, changing a constant, swapping an import. Don't use it as a shortcut around picking a unique `old_string`.
+
+## What gets shipped with ReVa
+
+ReVa's repo has a `ghidra_scripts/` directory (`reverse-engineering-assistant/ghidra_scripts/`) with a `sample_script.py`. Those ship with the extension and end up in Ghidra's script search path — they're read-only via `read-script`/`run-script` (you can't `write-script` to them). Drop new public-facing scripts there in the repo (not via the MCP tool) if you're a contributor; the MCP tool is for user-authored, runtime scripts.
+
+## Discoverability tips
+
+When the user asks for a script that "probably already exists":
+
+1. `list-scripts(nameFilter="...")` — search by file name.
+2. `list-scripts(pathFilter="...")` — search by directory (e.g. only the user dir).
+3. `read-script(scriptName="...")` on any hit that looks close to confirm.
+
+Don't re-implement a script that already exists in the user's `~/ghidra_scripts/` — read it, suggest running it, or `edit-script` it to fit the new requirement.

--- a/ReVa/skills/pyghidra-scripting/references/recipes.md
+++ b/ReVa/skills/pyghidra-scripting/references/recipes.md
@@ -1,0 +1,649 @@
+# `run-script` recipes
+
+Copy-pasteable inline `code` for the well-trodden tasks. Each recipe is a complete script body — pass it as `run-script(programPath=..., code=...)`. They assume the contract documented in SKILL.md (globals bound, no auto-transaction, monitor cancellation cooperative).
+
+## Iterate functions with a predicate
+
+```python
+import json
+out = []
+fm = currentProgram.getFunctionManager()
+for f in fm.getFunctions(True):
+    if monitor.isCancelled(): break
+    body = f.getBody()
+    if body.getNumAddresses() > 4096:
+        out.append({
+            "addr": str(f.getEntryPoint()),
+            "name": f.getName(),
+            "size": body.getNumAddresses(),
+        })
+print(json.dumps(out, indent=2))
+```
+
+## Find xrefs to a symbol with caller context
+
+```python
+import json
+sym = getSymbol("interesting_func", None)   # None = global namespace
+if sym is None:
+    print(json.dumps({"error": "symbol not found"}))
+else:
+    out = []
+    for ref in getReferencesTo(sym.getAddress()):
+        if monitor.isCancelled(): break
+        from_addr = ref.getFromAddress()
+        caller = getFunctionContaining(from_addr)
+        out.append({
+            "from": str(from_addr),
+            "type": str(ref.getReferenceType()),
+            "in_function": caller.getName() if caller else None,
+        })
+    print(json.dumps(out, indent=2))
+```
+
+## Batch rename functions matching a regex
+
+```python
+import re
+from ghidra.program.model.symbol import SourceType
+
+pattern = re.compile(r"^FUN_(00)?40([0-9a-f]{4})$")
+template = "candidate_{}"
+
+renamed = 0
+tx = currentProgram.startTransaction("Batch rename matching FUN_ pattern")
+try:
+    for f in currentProgram.getFunctionManager().getFunctions(True):
+        if monitor.isCancelled(): break
+        m = pattern.match(f.getName())
+        if m:
+            f.setName(template.format(m.group(2)), SourceType.USER_DEFINED)
+            renamed += 1
+    currentProgram.endTransaction(tx, True)
+except Exception:
+    currentProgram.endTransaction(tx, False)
+    raise
+print(f"renamed: {renamed}")
+```
+
+## Find callers of an imported symbol (handles thunks)
+
+PE/ELF binaries call imports through small thunk functions. The naive xrefs-to-symbol pattern finds the thunk, not the real users. `Function.getCallingFunctions(monitor)` walks back through thunks automatically — use it instead.
+
+```python
+import json
+target_name = "WinExec"
+
+# 1. Find the external function. Externals live in the symbol table with
+#    isExternal()=True. The Function object for an external is what
+#    getCallingFunctions traverses thunks against.
+fm = currentProgram.getFunctionManager()
+externals = [f for f in fm.getExternalFunctions() if f.getName() == target_name]
+if not externals:
+    print(json.dumps({"error": f"no external function {target_name}"})); raise SystemExit
+
+callers = set()
+for ext in externals:
+    # getCallingFunctions chases thunks automatically — direct from external
+    # to the real caller, skipping the trampoline that lives in .text.
+    for c in ext.getCallingFunctions(monitor):
+        if monitor.isCancelled(): break
+        callers.add((str(c.getEntryPoint()), c.getName(), c.isThunk()))
+
+# If you want both the thunk wrappers AND the real callers, also look at
+# functions whose body calls a thunk pointing at the external:
+for ext in externals:
+    for thunk_addr in ext.getFunctionThunkAddresses() or []:
+        thunk = fm.getFunctionAt(thunk_addr)
+        if thunk is None: continue
+        for c in thunk.getCallingFunctions(monitor):
+            callers.add((str(c.getEntryPoint()), c.getName(), c.isThunk()))
+
+out = [{"addr": a, "name": n, "is_thunk": t} for a, n, t in sorted(callers)]
+print(json.dumps(out, indent=2))
+```
+
+`getCallingFunctions` returns a `Set<Function>`; it skips the thunk indirection so the result is the *real* user code, not the trampoline. `func.isThunk()` lets you flag thunks if you want them treated differently. Note that `currentProgram.getFunctionManager().getExternalFunctions()` is the easy way to enumerate imports — `SymbolTable.getExternalSymbols()` includes data imports too.
+
+## Decompile-and-grep
+
+```python
+import json
+import re
+from ghidra.app.decompiler import DecompInterface
+
+needle = re.compile(r"\b(?:strcpy|strcat|sprintf|gets)\s*\(")
+hits = []
+
+decomp = DecompInterface()
+decomp.openProgram(currentProgram)
+try:
+    for f in currentProgram.getFunctionManager().getFunctions(True):
+        if monitor.isCancelled(): break
+        res = decomp.decompileFunction(f, 20, monitor)
+        if not res.decompileCompleted():
+            continue
+        c = res.getDecompiledFunction().getC()
+        for m in needle.finditer(c):
+            hits.append({
+                "addr": str(f.getEntryPoint()),
+                "name": f.getName(),
+                "match": m.group(0),
+            })
+            break   # one hit per function is enough
+finally:
+    decomp.dispose()
+
+print(json.dumps(hits, indent=2))
+```
+
+This decompiles every function — expensive. Filter first (e.g. by name pattern, or by whether the function references known-bad imports) before decompiling, when you can.
+
+## Dump strings with their referencers
+
+```python
+import json
+from ghidra.program.util import DefinedDataIterator
+
+out = []
+for data in DefinedDataIterator.definedStrings(currentProgram):
+    if monitor.isCancelled(): break
+    addr = data.getAddress()
+    value = data.getValue()
+    refs = []
+    for r in getReferencesTo(addr):
+        caller = getFunctionContaining(r.getFromAddress())
+        refs.append({
+            "from": str(r.getFromAddress()),
+            "in": caller.getName() if caller else None,
+        })
+    if refs:   # skip orphan strings
+        out.append({"addr": str(addr), "value": str(value), "refs": refs})
+
+print(json.dumps(out, indent=2))
+```
+
+## Walk the call graph from a root function
+
+```python
+import json
+from collections import deque
+
+root = getFunction("main")
+if root is None:
+    print(json.dumps({"error": "no main"}))
+else:
+    visited = set()
+    edges = []
+    q = deque([root])
+    while q:
+        if monitor.isCancelled(): break
+        f = q.popleft()
+        if f.getEntryPoint() in visited:
+            continue
+        visited.add(f.getEntryPoint())
+        for callee in f.getCalledFunctions(monitor):
+            edges.append({
+                "from": f.getName(),
+                "to": callee.getName(),
+                "to_addr": str(callee.getEntryPoint()),
+            })
+            q.append(callee)
+    print(json.dumps({"functions": len(visited), "edges": edges[:200]}, indent=2))
+```
+
+## Find functions that reference a specific data address
+
+```python
+import json
+target = toAddr(0x404020)
+out = []
+for ref in getReferencesTo(target):
+    if monitor.isCancelled(): break
+    caller = getFunctionContaining(ref.getFromAddress())
+    out.append({
+        "from": str(ref.getFromAddress()),
+        "in_function": caller.getName() if caller else None,
+        "type": str(ref.getReferenceType()),
+    })
+print(json.dumps(out, indent=2))
+```
+
+## Set a plate comment + EOL comment in one transaction
+
+```python
+tx = currentProgram.startTransaction("Annotate suspicious calls")
+try:
+    sites = [(toAddr(0x401234), "calls VirtualAlloc with RWX"),
+             (toAddr(0x401290), "loop body — copies shellcode into RWX page")]
+    for addr, note in sites:
+        setEOLComment(addr, note)
+    setPlateComment(toAddr(0x401200), "suspected shellcode loader")
+    currentProgram.endTransaction(tx, True)
+except Exception:
+    currentProgram.endTransaction(tx, False)
+    raise
+print("done")
+```
+
+## Read raw bytes from `.text`
+
+```python
+import jpype
+block = currentProgram.getMemory().getBlock(".text")
+buf = jpype.JByte[64]
+block.getBytes(block.getStart(), buf)
+print(" ".join(f"{b & 0xff:02x}" for b in buf))
+```
+
+## Iterate every instruction in a function
+
+```python
+f = getFunctionContaining(toAddr(0x401000))
+listing = currentProgram.getListing()
+for instr in listing.getInstructions(f.getBody(), True):
+    if monitor.isCancelled(): break
+    print(f"{instr.getAddress()}  {instr}")
+```
+
+## Quick "is this binary stripped?" check
+
+```python
+import json
+fm = currentProgram.getFunctionManager()
+total = 0; named = 0
+for f in fm.getFunctions(True):
+    if monitor.isCancelled(): break
+    total += 1
+    n = f.getName()
+    if not (n.startswith("FUN_") or n.startswith("thunk_FUN_")):
+        named += 1
+ratio = (named / total) if total else 0
+print(json.dumps({"total": total, "named": named, "ratio": round(ratio, 3),
+                  "verdict": "stripped" if ratio < 0.05 else "has-symbols"}))
+```
+
+## Print pagination-friendly tabular output
+
+```python
+out = []
+for f in currentProgram.getFunctionManager().getFunctions(True):
+    if monitor.isCancelled(): break
+    out.append(f"{str(f.getEntryPoint()):>12}  {f.getBody().getNumAddresses():>6}  {f.getName()}")
+print("\n".join(out[:500]))    # cap before printing to stay under output limit
+if len(out) > 500:
+    print(f"... ({len(out) - 500} more truncated)")
+```
+
+The output cap is per-stream (default 64K chars). If you have a lot of rows, truncate explicitly with a marker rather than letting the cap silently cut you off.
+
+## Trace the constant passed to argN of every call to `target_func`
+
+This is the canonical PCode data-flow trick — given a callee, find every callsite, and for each callsite figure out which constant was passed as the Nth argument. The use cases are endless: which file path is opened, which permission flag is requested, which crypto algorithm id is selected. See `decompiler-pcode.md` for the underlying APIs.
+
+```python
+import json
+from ghidra.app.decompiler import DecompInterface, DecompileOptions
+from ghidra.program.model.pcode import PcodeOp
+
+target_name = "WinExec"          # the callee we care about
+arg_slot = 0                     # 0-indexed argument
+
+# Find the function (or external symbol) we're tracing into
+target = getFunction(target_name)
+target_addr = target.getEntryPoint() if target else None
+if target_addr is None:
+    # try external symbol
+    for s in currentProgram.getSymbolTable().getExternalSymbols():
+        if s.getName() == target_name:
+            target_addr = s.getAddress(); break
+
+if target_addr is None:
+    print(json.dumps({"error": f"no symbol {target_name}"})); raise SystemExit
+
+# Set of caller functions to decompile
+callers = set()
+for ref in getReferencesTo(target_addr):
+    f = getFunctionContaining(ref.getFromAddress())
+    if f: callers.add(f)
+
+def trace_const(vn, depth=10):
+    seen = set()
+    while vn is not None and depth > 0:
+        if vn.isConstant(): return vn.getOffset()
+        key = id(vn)
+        if key in seen: return None
+        seen.add(key)
+        d = vn.getDef()
+        if d is None: return None
+        op = d.getOpcode()
+        if op in (PcodeOp.COPY, PcodeOp.CAST, PcodeOp.INT_ZEXT, PcodeOp.INT_SEXT):
+            vn = d.getInput(0)
+        else:
+            return None
+        depth -= 1
+    return None
+
+decomp = DecompInterface()
+decomp.openProgram(currentProgram)
+hits = []
+try:
+    for f in callers:
+        if monitor.isCancelled(): break
+        res = decomp.decompileFunction(f, 30, monitor)
+        if not res.decompileCompleted(): continue
+        hf = res.getHighFunction()
+        ops = hf.getPcodeOps()
+        while ops.hasNext():
+            op = ops.next()
+            if op.getOpcode() not in (PcodeOp.CALL, PcodeOp.CALLIND): continue
+            # input(0) = callee addr; arguments are input(1..)
+            inputs = op.getInputs()
+            if len(inputs) <= arg_slot + 1: continue
+            # only callsites of the target
+            callee_vn = inputs[0]
+            if not (callee_vn.isAddress() and callee_vn.getAddress() == target_addr): continue
+            const = trace_const(inputs[arg_slot + 1])
+            hits.append({
+                "in_function": f.getName(),
+                "call_site": str(op.getSeqnum().getTarget()),
+                "arg_value": hex(const) if const is not None else None,
+            })
+finally:
+    decomp.dispose()
+print(json.dumps(hits, indent=2))
+```
+
+## Register touches per function
+
+Lightweight read-only pass — for each function, list every register read or written. Useful for finding "this function clobbers RBX" or "this function reads from RDI without setting it" anomalies.
+
+```python
+import json
+from ghidra.program.model.lang import Register
+
+out = []
+listing = currentProgram.getListing()
+for f in currentProgram.getFunctionManager().getFunctions(True):
+    if monitor.isCancelled(): break
+    reads, writes = set(), set()
+    for ins in listing.getInstructions(f.getBody(), True):
+        for r in ins.getInputObjects():
+            if isinstance(r, Register): reads.add(r.getName())
+        for r in ins.getResultObjects():
+            if isinstance(r, Register): writes.add(r.getName())
+    # interesting cases: read-only registers (read but never written)
+    read_only = sorted(reads - writes)
+    if read_only:
+        out.append({
+            "addr": str(f.getEntryPoint()),
+            "name": f.getName(),
+            "read_only_regs": read_only,
+        })
+print(json.dumps(out[:50], indent=2))
+```
+
+## Parallel decompilation across the whole program
+
+Use this when you'd otherwise decompile more than ~10 functions. `ParallelDecompiler` runs decompilation across all CPU cores; the `process` callback runs once per function on the worker.
+
+```python
+import json
+from ghidra.app.decompiler import DecompInterface, DecompileOptions
+from ghidra.app.decompiler.parallel import (
+    ParallelDecompiler, DecompilerCallback, DecompileConfigurer,
+)
+
+class Configurer(DecompileConfigurer):
+    def configure(self, decompiler):
+        opts = DecompileOptions()
+        opts.grabFromProgram(currentProgram)
+        decompiler.setOptions(opts)
+        decompiler.toggleSyntaxTree(True)
+        decompiler.setSimplificationStyle("decompile")
+
+class Stats(DecompilerCallback):
+    def __init__(self, prog):
+        super().__init__(prog, Configurer())
+    def process(self, results, monitor):
+        if not results.decompileCompleted(): return None
+        hf = results.getHighFunction()
+        # Pick anything you want collected — keep it small (returned across processes).
+        return {
+            "name": results.getFunction().getName(),
+            "varnodes": hf.getNumVarnodes(),
+            "blocks": hf.getBasicBlocks().size(),
+        }
+
+funcs = list(currentProgram.getFunctionManager().getFunctions(True))
+cb = Stats(currentProgram)
+try:
+    results = ParallelDecompiler.decompileFunctions(cb, funcs, monitor)
+finally:
+    cb.dispose()
+
+# results is a List<Object> in caller order; filter Nones and print
+out = [r for r in (results or []) if r is not None]
+print(json.dumps(out[:50], indent=2))
+print(f"total: {len(out)} successful decompilations")
+```
+
+The `process()` return value is collected into a Java `List` you can read after `decompileFunctions` returns. Keep returned values small — they cross the worker boundary.
+
+## Emulate a function to recover an obfuscated string
+
+Ghidra's `EmulatorHelper` runs PCode in-process. The classic use is "this function decrypts a string at runtime; emulate it and read the result out of memory." It's simpler than `JitPcodeEmulator` and right for most one-shot tasks.
+
+```python
+from ghidra.app.emulator import EmulatorHelper
+from ghidra.program.model.symbol import SymbolType
+
+func = getFunction("decrypt_string")
+if func is None: raise SystemExit("no decrypt_string")
+
+emu = EmulatorHelper(currentProgram)
+try:
+    # Pick a return address that doesn't exist in the program — when the
+    # emulator's PC lands there, we know the function returned.
+    ret_addr = toAddr(0xDEAD0000)
+
+    # x86-64 calling convention example: arg in RDI, stack alignment
+    stack_top = 0x70000000
+    emu.writeRegister(emu.getStackPointerRegister(), stack_top)
+    # Push the fake return address
+    emu.writeMemoryValue(toAddr(stack_top - 8), 8, ret_addr.getOffset())
+    emu.writeRegister(emu.getStackPointerRegister(), stack_top - 8)
+
+    # Arg 1 in RDI — pointer to a 64-byte buffer in some unused memory
+    buf_addr = 0x20000000
+    emu.writeRegister("RDI", buf_addr)
+
+    # Set PC and run until we hit the fake return address
+    emu.setBreakpoint(ret_addr)
+    if not emu.run(func.getEntryPoint(), None, monitor):
+        print("emulation stopped early:", emu.getLastError())
+    else:
+        data = emu.readMemory(toAddr(buf_addr), 64)
+        # data is a Java byte[]; convert to Python bytes (signed → unsigned)
+        decoded = bytes(b & 0xff for b in data)
+        # strip trailing zero bytes
+        decoded = decoded.rstrip(b"\x00")
+        print(decoded.decode("utf-8", errors="replace"))
+finally:
+    emu.dispose()
+```
+
+Notes:
+- `EmulatorHelper` doesn't auto-set up the stack or arguments — that's on you. Calling convention matters: x86-64 SysV puts args in RDI/RSI/RDX/RCX/R8/R9; Windows x64 uses RCX/RDX/R8/R9; ARM64 uses X0–X7.
+- Set a breakpoint at an unmapped address you control (e.g. `0xDEAD0000`) and push it as the return address so `emu.run()` stops there cleanly.
+- For functions that call external libraries (malloc, printf, …), the emulator will dive into stubs and likely fail. Either hook those addresses with `emu.setBreakpoint(...)` and emulate the effect yourself, or stay within self-contained leaf functions.
+- For long emulations, check `monitor.isCancelled()` inside a loop that single-steps with `emu.step(monitor)` instead of using `emu.run()`.
+
+## Recursive xrefs: every string reachable from a function
+
+Walks the call graph forward from a function, collecting every string referenced anywhere in the reachable set. Useful for "what data does this code path touch?"
+
+```python
+import json
+from ghidra.program.model.listing import CodeUnit
+
+root = getFunction("main")
+if root is None: raise SystemExit("no main")
+
+visited = set()
+strings = []
+
+def visit(f, depth=0):
+    key = f.getEntryPoint()
+    if key in visited or monitor.isCancelled(): return
+    visited.add(key)
+    # Strings referenced from this function's body
+    for ins in currentProgram.getListing().getInstructions(f.getBody(), True):
+        for ref in ins.getReferencesFrom():
+            target = ref.getToAddress()
+            data = getDataAt(target)
+            if data and data.hasStringValue():
+                strings.append({
+                    "in_function": f.getName(),
+                    "addr": str(target),
+                    "value": str(data.getValue()),
+                })
+    # Recurse into callees
+    for callee in f.getCalledFunctions(monitor):
+        visit(callee, depth + 1)
+
+visit(root)
+print(json.dumps({"reachable_functions": len(visited),
+                  "string_refs": strings[:100],
+                  "truncated": len(strings) > 100}, indent=2))
+```
+
+`Function.getCalledFunctions(monitor)` and `getCallingFunctions(monitor)` are the easy way to traverse the call graph — they handle thunks and indirect resolution that walking xrefs manually wouldn't.
+
+## Define a struct and apply it to memory
+
+Higher-leverage than renaming: once a region of bytes is typed, the listing shows named fields and the decompiler propagates types through every consumer.
+
+```python
+from ghidra.program.model.data import (
+    StructureDataType, IntegerDataType, PointerDataType, CharDataType,
+    DataTypeConflictHandler,
+)
+
+dtm = currentProgram.getDataTypeManager()
+
+# Build a struct from scratch (0 = auto-grow as fields are added)
+hdr = StructureDataType("WidgetHeader", 0)
+hdr.add(IntegerDataType(),                "magic",   "Signature 0xDEADBEEF")
+hdr.add(IntegerDataType(),                "version", None)
+hdr.add(IntegerDataType(),                "flags",   None)
+hdr.add(PointerDataType(CharDataType()),  "name",    "UTF-8, NUL-terminated")
+
+tx = currentProgram.startTransaction("Define + apply WidgetHeader")
+try:
+    hdr = dtm.addDataType(hdr, DataTypeConflictHandler.DEFAULT_HANDLER)
+    # Apply at known addresses
+    for addr_int in [0x404000, 0x404100, 0x404200]:
+        data = createData(toAddr(addr_int), hdr)
+    currentProgram.endTransaction(tx, True)
+except Exception:
+    currentProgram.endTransaction(tx, False)
+    raise
+
+# Walk the fields you just defined
+data = getDataAt(toAddr(0x404000))
+for i in range(data.getNumComponents()):
+    comp = data.getComponent(i)
+    print(f"+{comp.getOffset():04x}  {comp.getFieldName()} = {comp.getValue()}")
+```
+
+`createData()` clears whatever was at the address first, so this is safe over previously-defined data — but mid-instruction it'll cause disassembly trouble. Apply struct types to data regions, not into code. For an existing type by path, look it up: `dtm.getDataType("/some_header.h/WidgetHeader")`. For a free-form type string from a user, use `DataTypeParserUtil.parseDataTypeObjectFromString(dtm, "WidgetHeader *")` (from ReVa's `reva.util`).
+
+## Set a function signature programmatically
+
+When data-flow analysis tells you a function's signature is wrong — say it's really `int decrypt(char *out, int out_len, const char *in)` — commit the corrected signature so the decompiler propagates the new types everywhere it's called.
+
+```python
+from ghidra.program.model.listing import ParameterImpl, ReturnParameterImpl, Function
+from ghidra.program.model.data import (
+    IntegerDataType, PointerDataType, CharDataType, VoidDataType,
+)
+from ghidra.program.model.symbol import SourceType
+
+func = getFunction("FUN_00401200")
+if func is None: raise SystemExit("no such function")
+
+# Build the parameter list
+prog = currentProgram
+params = [
+    ParameterImpl("out",     PointerDataType(CharDataType()),    prog),
+    ParameterImpl("out_len", IntegerDataType(),                  prog),
+    ParameterImpl("in",      PointerDataType(CharDataType()),    prog),
+]
+ret = ReturnParameterImpl(IntegerDataType(), prog)
+
+tx = prog.startTransaction("Set decrypt() signature")
+try:
+    func.updateFunction(
+        None,                                       # calling convention (None = unchanged)
+        ret,                                        # new return param
+        params,                                     # new parameter list
+        Function.FunctionUpdateType.DYNAMIC_STORAGE_ALL_PARAMS,
+        True,                                       # force=true (override existing)
+        SourceType.USER_DEFINED,
+    )
+    func.setName("decrypt", SourceType.USER_DEFINED)
+    prog.endTransaction(tx, True)
+except Exception:
+    prog.endTransaction(tx, False)
+    raise
+
+print(f"signature: {func.getSignature()}")
+```
+
+The `FunctionUpdateType` enum controls how Ghidra computes storage:
+- `DYNAMIC_STORAGE_ALL_PARAMS` — Ghidra picks registers/stack slots based on calling convention. Almost always what you want.
+- `CUSTOM_STORAGE` — you also supply explicit storage per parameter (needed for non-standard ABIs).
+
+Pass `"__stdcall"`, `"__fastcall"`, `"__cdecl"`, etc. as the first argument to change the calling convention. Pass `None` to keep the current one.
+
+For commits driven by the *decompiler's* inferred signature (after data-flow analysis improves things), the related shortcut is `HighFunctionDBUtil.commitParamsToDatabase(hf, True, SourceType.USER_DEFINED)` — it takes whatever the decompiler currently shows and writes it back without you having to spell out each `ParameterImpl`.
+
+## Persist a decompiler-derived rename
+
+When the decompiler shows a local named `iVar3` and you want to commit a better name, that's a `HighSymbol` rename, not a plain symbol rename. Use `HighFunctionDBUtil`:
+
+```python
+from ghidra.app.decompiler import DecompInterface
+from ghidra.program.model.pcode import HighFunctionDBUtil
+from ghidra.program.model.symbol import SourceType
+
+func = getFunctionAt(toAddr(0x401000))
+target_name = "iVar3"          # the decompiler name we want to rename
+new_name = "loop_counter"
+
+decomp = DecompInterface()
+decomp.openProgram(currentProgram)
+try:
+    res = decomp.decompileFunction(func, 30, monitor)
+    if not res.decompileCompleted(): raise SystemExit("decompile failed")
+    hf = res.getHighFunction()
+    it = hf.getLocalSymbolMap().getSymbols()
+    target = None
+    while it.hasNext():
+        s = it.next()
+        if s.getName() == target_name:
+            target = s; break
+    if target is None: raise SystemExit(f"no {target_name}")
+    tx = currentProgram.startTransaction(f"Rename {target_name} -> {new_name}")
+    try:
+        HighFunctionDBUtil.updateDBVariable(target, new_name, None, SourceType.USER_DEFINED)
+        currentProgram.endTransaction(tx, True)
+    except Exception:
+        currentProgram.endTransaction(tx, False); raise
+finally:
+    decomp.dispose()
+print(f"renamed {target_name} -> {new_name} in {func.getName()}")
+```
+
+Pass a `DataType` instead of `None` to retype at the same time. For full signature commits (after data-flow analysis improves parameters), use `HighFunctionDBUtil.commitParamsToDatabase(hf, True, SourceType.USER_DEFINED)`.


### PR DESCRIPTION
## Summary
- New Claude Code marketplace skill at `ReVa/skills/pyghidra-scripting/` that teaches the model how to drive ReVa's five scripting MCP tools (`run-script`, `list-scripts`, `read-script`, `write-script`, `edit-script`).
- `SKILL.md` covers the execution contract — PyGhidra-only runtime gate, no auto-transaction, cooperative cancellation via `monitor.isCancelled()`, 64K stdout/stderr cap, result schema.
- Five bundled references for progressive disclosure: `flat-api.md` (FlatProgramAPI + address sets + imports/thunks + datatypes), `decompiler-pcode.md` (HighFunction / Varnode / PcodeOp / ParallelDecompiler / HighFunctionDBUtil), `jpype-interop.md` (Java/Python boundary), `recipes.md` (20 copy-pasteable inline-code patterns — argN tracing, EmulatorHelper, struct definition, signature commits, parallel decomp, etc.), and `persistent-scripts.md` (saved-script workflow).
- Patterns and APIs mined from Ghidra's bundled example scripts and the PyGhidra README/source in `~/dev/ghidra`.

Triggers on phrases like "write a pyghidra script", "run python against this program", "use the Ghidra Flat API directly", or any task an existing ReVa MCP tool can't cover where the right answer is "drop into PyGhidra for one call." Auto-discovered by the marketplace (`ReVa/.claude-plugin/plugin.json` + `marketplace.json` unchanged).

## Test plan
- [ ] Confirm the skill is listed by `/skills` after installing the marketplace plugin update
- [ ] Trigger check: ask "write a pyghidra script to find every call to WinExec with the first argument as a constant" — skill should fire
- [ ] Anti-trigger check: ask "decompile this function" or "list strings in this binary" — should still route to the dedicated ReVa MCP tools, not this skill
- [ ] Run one of the recipes end-to-end via `run-script` (e.g. "Trace argN" or "Register touches per function") to confirm the code samples execute against a real program
- [ ] Verify the SKILL.md frontmatter parses cleanly (description length is on the long side at ~700 chars — confirm it's still accepted)