### PR TITLE
feat(decompiler): preserve unreachable code by default

### DIFF
--- a/src/main/java/reva/tools/decompiler/DecompilerToolProvider.java
+++ b/src/main/java/reva/tools/decompiler/DecompilerToolProvider.java
@@ -28,6 +28,7 @@ import java.util.regex.PatternSyntaxException;
 import java.util.regex.Matcher;
 
 import ghidra.app.decompiler.DecompInterface;
+import ghidra.app.decompiler.DecompileOptions;
 import ghidra.app.decompiler.DecompileResults;
 import ghidra.app.decompiler.DecompiledFunction;
 import ghidra.app.decompiler.ClangTokenGroup;
@@ -213,6 +214,10 @@ public class DecompilerToolProvider extends AbstractToolProvider {
         decompiler.toggleCCode(true);
         decompiler.toggleSyntaxTree(true);
         decompiler.setSimplificationStyle("decompile");
+
+        DecompileOptions options = new DecompileOptions();
+        options.setEliminateUnreachable(false);
+        decompiler.setOptions(options);
 
         if (!decompiler.openProgram(program)) {
             logError(toolName + ": Failed to initialize decompiler for " + program.getName());


### PR DESCRIPTION
## Summary
- Set `DecompileOptions.eliminateUnreachable=false` in `createConfiguredDecompiler()` so every decompilation flow (get-decompilation, search-decompilation, the diff regen after rename/retype, and the bulk caller/referencer tools) retains code Ghidra would otherwise drop as dead.
- Unreachable branches frequently carry meaningful signal in RE — opaque predicates, anti-analysis stubs, switch table tails, and paths the optimizer mis-classifies — and the LLM should see them.

## Test plan
- [x] `gradle test` — Java unit tests pass
- [x] `gradle integrationTest` — 125/125 integration tests pass (0 failures, 0 errors)
- [x] `uv run pytest` — 153 passed, 2 skipped (Python suite)