### PR TITLE
chore(deps): combined dependabot bumps — jetty 12.1.9 + setup-ghidra v2.1.2

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Install Ghidra
         # Sets GHIDRA_INSTALL_DIR for subsequent steps and the agent session.
-        uses: antoniovazquezblanco/setup-ghidra@v2.1.1
+        uses: antoniovazquezblanco/setup-ghidra@v2.1.2
         with:
           version: "latest"
           auth_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-ghidra.yml
+++ b/.github/workflows/publish-ghidra.yml
@@ -33,7 +33,7 @@ jobs:
         java-version: "21"
         distribution: "microsoft"
     - name: Install Ghidra 🐉
-      uses: antoniovazquezblanco/setup-ghidra@v2.1.1
+      uses: antoniovazquezblanco/setup-ghidra@v2.1.2
       with:
         version: ${{ matrix.ghidra-version }}
         auth_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-ghidra.yml
+++ b/.github/workflows/test-ghidra.yml
@@ -39,7 +39,7 @@ jobs:
         distribution: "microsoft"
 
     - name: Install Ghidra 🐉
-      uses: antoniovazquezblanco/setup-ghidra@v2.1.1
+      uses: antoniovazquezblanco/setup-ghidra@v2.1.2
       with:
         version: ${{ matrix.ghidra-version }}
         auth_token: ${{ secrets.GITHUB_TOKEN }}
@@ -104,7 +104,7 @@ jobs:
         distribution: "microsoft"
 
     - name: Install Ghidra 🐉
-      uses: antoniovazquezblanco/setup-ghidra@v2.1.1
+      uses: antoniovazquezblanco/setup-ghidra@v2.1.2
       with:
         version: "latest"
         auth_token: ${{ secrets.GITHUB_TOKEN }}
@@ -155,7 +155,7 @@ jobs:
         queries: security-extended,security-and-quality
 
     - name: Install Ghidra 🐉
-      uses: antoniovazquezblanco/setup-ghidra@v2.1.1
+      uses: antoniovazquezblanco/setup-ghidra@v2.1.2
       with:
         version: "latest"
         auth_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-headless.yml
+++ b/.github/workflows/test-headless.yml
@@ -47,7 +47,7 @@ jobs:
         python-version: "3.10"
 
     - name: Install Ghidra ${{ matrix.ghidra-version }}
-      uses: antoniovazquezblanco/setup-ghidra@v2.1.1
+      uses: antoniovazquezblanco/setup-ghidra@v2.1.2
       with:
         version: ${{ matrix.ghidra-version }}
         auth_token: ${{ secrets.GITHUB_TOKEN }}

--- a/build.gradle
+++ b/build.gradle
@@ -113,8 +113,8 @@ dependencies {
 	implementation "io.modelcontextprotocol.sdk:mcp-json-jackson2"
 	implementation "jakarta.servlet:jakarta.servlet-api:6.1.0"
 	// Add Jetty for embedded servlet support
-	implementation "org.eclipse.jetty:jetty-server:12.1.8"
-	implementation "org.eclipse.jetty.ee10:jetty-ee10-servlet:12.1.8"
+	implementation "org.eclipse.jetty:jetty-server:12.1.9"
+	implementation "org.eclipse.jetty.ee10:jetty-ee10-servlet:12.1.9"
 
 	// Force Jackson 2.21.x to be compatible with MCP SDK
 	implementation "com.fasterxml.jackson.core:jackson-core:2.21.3"


### PR DESCRIPTION
## Summary

Combines the three live dependabot PRs into one branch so CI tests them together:

- #297 `org.eclipse.jetty:jetty-server` 12.1.8 → 12.1.9
- #298 `org.eclipse.jetty.ee10:jetty-ee10-servlet` 12.1.8 → 12.1.9
- #296 `antoniovazquezblanco/setup-ghidra` v2.1.1 → v2.1.2

Dependabot PRs #255 (jackson-annotations 2.20 → 2.21) and #274 (mockito-core 5.22.0 → 5.23.0) are already superseded by commit 2606bdc on main — those bumps are in place at the current versions (Jackson 2.21.3, mockito 5.23.0).

## Test plan

- [ ] Test Ghidra Extension workflow (Ubuntu, Ghidra 12.0/12.0.1/12.0.2/12.0.3/12.0.4/latest)
- [ ] Test Headless Mode workflow
- [ ] Lint and Check
- [ ] CodeQL

Individual dependabot PRs were green on Ubuntu CI; only macOS jobs failed (60-min timeouts unrelated to the bumps).

https://claude.ai/code/session_014mAgdhBti2HsPQTvzPKiX6

---
_Generated by [Claude Code](https://claude.ai/code/session_014mAgdhBti2HsPQTvzPKiX6)_