### PR TITLE
feat(ghidra): add Ghidra 12.1 support

### DIFF
--- a/.github/workflows/publish-ghidra.yml
+++ b/.github/workflows/publish-ghidra.yml
@@ -22,6 +22,7 @@ jobs:
             "12.0.2",
             "12.0.3",
             "12.0.4",
+            "12.1",
         ]
     name: Build distribution 📦
     runs-on: ubuntu-latest

--- a/.github/workflows/test-ghidra.yml
+++ b/.github/workflows/test-ghidra.yml
@@ -23,6 +23,7 @@ jobs:
             "12.0.2",
             "12.0.3",
             "12.0.4",
+            "12.1",
             "latest",
         ]
     name: Test on Ghidra ${{ matrix.ghidra-version }}

--- a/.github/workflows/test-headless.yml
+++ b/.github/workflows/test-headless.yml
@@ -23,6 +23,7 @@ jobs:
           - "12.0.2"
           - "12.0.3"
           - "12.0.4"
+          - "12.1"
           - "latest"
       fail-fast: false  # Continue other tests if one fails
 
@@ -56,6 +57,16 @@ jobs:
       uses: gradle/actions/setup-gradle@v6
       with:
         gradle-version: "8.14"
+
+    # Ghidra releases ship prebuilt decompiler natives for Linux and Windows but
+    # NOT macOS. Without this, decompilation silently returns nothing on macOS
+    # runners and any decompiler-dependent headless test fails. Ghidra searches
+    # build/os/<platform> (where this task writes) before os/<platform>, so the
+    # installed PyGhidra runtime picks these up. Linux runners already have
+    # prebuilt natives, so the step is macOS-only.
+    - name: Build Ghidra natives (macOS only)
+      if: runner.os == 'macOS'
+      run: gradle -p "$GHIDRA_INSTALL_DIR/support/gradle" buildNatives
 
     - name: Build ReVa Extension
       run: gradle clean buildExtension --no-build-cache

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -270,7 +270,7 @@ Install via: `claude plugin marketplace add cyberkaida/reverse-engineering-assis
 
 ### Python
 - Python: 3.10+ (managed via uv)
-- PyGhidra: 3.0.0+ (Ghidra initialization)
+- PyGhidra: 3.1.0+ (Ghidra initialization)
 - MCP: Latest (stdio transport implementation)
 - httpx + httpx-sse: MCP HTTP client (for StdioBridge)
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -150,7 +150,7 @@ ReVa is designed to handle the Ghidra lifecycle correctly:
 | MCP SDK | v0.17.0 |
 | Jackson | 2.20.x |
 | Jetty | 11.0.26 |
-| PyGhidra | 3.0.0+ |
+| PyGhidra | 3.1.0+ |
 | JUnit | 4 (NOT 5) |
 
 ### Build Commands

--- a/build.gradle
+++ b/build.gradle
@@ -143,8 +143,27 @@ dependencies {
 // "IllegalStateException: Cannot replace filter factory". Specifying the
 // factory at JVM startup lets Ghidra lazily reuse it instead of replacing it.
 // Matches Ghidra's own gradle/javaTestProject.gradle test configuration.
+//
+// GhidraSerialFilterFactory only exists in Ghidra 12.1+, so gate the JVM arg on
+// the installed version: setting it for an older Ghidra makes every test worker
+// fail at startup with "invalid jdk.serialFilterFactory: ClassNotFoundException".
+def ghidraSupportsSerialFilterFactory = {
+	def propsFile = new File(ghidraInstallDir, "Ghidra/application.properties")
+	if (!propsFile.exists()) {
+		return false
+	}
+	def props = new Properties()
+	propsFile.withInputStream { props.load(it) }
+	def parts = (props.getProperty("application.version", "0") =~ /\d+/).collect { it as int }
+	def major = parts.size() > 0 ? parts[0] : 0
+	def minor = parts.size() > 1 ? parts[1] : 0
+	return major > 12 || (major == 12 && minor >= 1)
+}()
+
 test {
-	jvmArgs '-Djdk.serialFilterFactory=ghidra.framework.remote.GhidraSerialFilterFactory'
+	if (ghidraSupportsSerialFilterFactory) {
+		jvmArgs '-Djdk.serialFilterFactory=ghidra.framework.remote.GhidraSerialFilterFactory'
+	}
 }
 
 task integrationTest(type: Test) {
@@ -160,8 +179,11 @@ task integrationTest(type: Test) {
 	systemProperty 'java.awt.headless', 'false'
 
 	// See note on the `test` task: Ghidra 12.1+ requires the serial filter
-	// factory to be specified at JVM startup for Gradle test workers.
-	jvmArgs '-Djdk.serialFilterFactory=ghidra.framework.remote.GhidraSerialFilterFactory'
+	// factory to be specified at JVM startup for Gradle test workers, and the
+	// class only exists on 12.1+, so gate it the same way.
+	if (ghidraSupportsSerialFilterFactory) {
+		jvmArgs '-Djdk.serialFilterFactory=ghidra.framework.remote.GhidraSerialFilterFactory'
+	}
 
 	// Exclude suite classes
 	exclude '**/*Suite*'

--- a/build.gradle
+++ b/build.gradle
@@ -135,6 +135,18 @@ dependencies {
 	// pcodeTestImplementation "junit:junit:4.13.2"
 }
 
+// Ghidra 12.1+ installs a global deserialization filter factory during
+// ApplicationConfiguration init (GhidraObjectInputFilter). Java's
+// ObjectInputFilter.Config.setSerialFilterFactory() may only be called once,
+// before any deserialization. Gradle test workers deserialize over their
+// daemon socket first, locking the factory to the JVM builtin and causing
+// "IllegalStateException: Cannot replace filter factory". Specifying the
+// factory at JVM startup lets Ghidra lazily reuse it instead of replacing it.
+// Matches Ghidra's own gradle/javaTestProject.gradle test configuration.
+test {
+	jvmArgs '-Djdk.serialFilterFactory=ghidra.framework.remote.GhidraSerialFilterFactory'
+}
+
 task integrationTest(type: Test) {
 	group 'verification'
 	description 'Runs integration tests (tests that require GUI/headed environment)'
@@ -146,6 +158,10 @@ task integrationTest(type: Test) {
 
 	// These tests require a GUI environment
 	systemProperty 'java.awt.headless', 'false'
+
+	// See note on the `test` task: Ghidra 12.1+ requires the serial filter
+	// factory to be specified at JVM startup for Gradle test workers.
+	jvmArgs '-Djdk.serialFilterFactory=ghidra.framework.remote.GhidraSerialFilterFactory'
 
 	// Exclude suite classes
 	exclude '**/*Suite*'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "pyghidra>=3.0.0",
+    "pyghidra>=3.1.0",
     "mcp",
     "httpx>=0.27.0,<1.0",
     "httpx-sse>=0.4.0",

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -9,7 +9,7 @@ This file provides guidance for Claude Code when working with the ReVa source co
 | **MCP SDK Version** | v1.1.1 |
 | **Jackson Version** | 2.21.x |
 | **Jetty Version** | 11.0.26 |
-| **PyGhidra Version** | 3.0.0+ |
+| **PyGhidra Version** | 3.1.0+ |
 | **JUnit Version** | JUnit 4 (NOT JUnit 5) |
 | **Build Command** | `gradle` (NOT `./gradlew`) |
 | **Unit Tests** | `gradle test` |

--- a/src/main/java/reva/headless/CLAUDE.md
+++ b/src/main/java/reva/headless/CLAUDE.md
@@ -11,7 +11,7 @@ This file provides guidance for Claude Code when working with the ReVa headless 
 | **Default Host** | 127.0.0.1 |
 | **MCP SDK Version** | v0.17.0 |
 | **Jackson Version** | 2.20.x |
-| **PyGhidra Version** | 3.0.0+ |
+| **PyGhidra Version** | 3.1.0+ |
 | **Startup Time** | 4-7 seconds |
 | **Memory Usage** | ~250-400 MB |
 

--- a/src/main/java/reva/services/CLAUDE.md
+++ b/src/main/java/reva/services/CLAUDE.md
@@ -12,7 +12,7 @@ This file provides guidance for working with the ReVa services package, which im
 | **Implementation** | `McpServerManager` |
 | **MCP SDK Version** | v0.17.0 |
 | **Jackson Version** | 2.20.x |
-| **PyGhidra Version** | 3.0.0+ |
+| **PyGhidra Version** | 3.1.0+ |
 
 ## Package Overview
 

--- a/src/test.slow/java/reva/RevaIntegrationTestBase.java
+++ b/src/test.slow/java/reva/RevaIntegrationTestBase.java
@@ -24,8 +24,14 @@ import org.junit.Before;
 import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.AfterClass;
+import org.junit.Rule;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
 
 import static org.junit.Assert.fail;
+
+import ghidra.framework.Application;
+import ghidra.framework.OSFileNotFoundException;
 
 import java.time.Duration;
 import java.util.Map;
@@ -72,6 +78,42 @@ public abstract class RevaIntegrationTestBase extends AbstractGhidraHeadedIntegr
     protected ConfigManager configManager;
     protected McpServerManager serverManager;
     protected ObjectMapper objectMapper;
+
+    /**
+     * On test failure, surface an actionable hint when the failure is likely caused by a
+     * missing Ghidra decompiler native (macOS ships no prebuilt decompiler). This turns a
+     * confusing "Decompilation should not be empty" into a clear "run buildNatives".
+     */
+    @Rule
+    public final TestWatcher decompilerNativeHintWatcher = new TestWatcher() {
+        @Override
+        protected void failed(Throwable e, Description description) {
+            DecompilerNativeHint
+                .hintForFailure(System.getProperty("os.name"), isDecompileNativeAvailable())
+                .ifPresent(hint -> {
+                    System.err.println();
+                    System.err.println("================================ ReVa test hint ================================");
+                    System.err.println(hint);
+                    System.err.println("================================================================================");
+                });
+        }
+    };
+
+    /**
+     * Determine whether Ghidra can locate its decompiler native binary, mirroring how
+     * {@code DecompileProcessFactory} resolves it. Only a definitive "not found" reports
+     * false; any other error is treated as "available" so the hint is never misleading.
+     */
+    private static boolean isDecompileNativeAvailable() {
+        try {
+            Application.getOSFile("decompile");
+            return true;
+        } catch (OSFileNotFoundException e) {
+            return false;
+        } catch (Throwable t) {
+            return true;
+        }
+    }
 
 
     /**

--- a/src/test/java/reva/DecompilerNativeHint.java
+++ b/src/test/java/reva/DecompilerNativeHint.java
@@ -1,0 +1,58 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reva;
+
+import java.util.Optional;
+
+/**
+ * Helper for integration tests: builds an actionable hint when a test failure is
+ * likely caused by missing Ghidra native binaries.
+ *
+ * <p>Ghidra releases ship prebuilt {@code decompile} binaries for Linux and Windows
+ * but not for macOS, so a fresh macOS install (especially Apple Silicon) has no
+ * decompiler native until {@code buildNatives} is run. Without it, decompilation
+ * silently yields nothing and decompiler integration tests fail with confusing
+ * assertions ("Decompilation should not be empty"). This helper surfaces the fix.
+ */
+public final class DecompilerNativeHint {
+
+    private DecompilerNativeHint() {
+    }
+
+    /**
+     * Returns a hint to run {@code buildNatives}, but only when the failure was on
+     * macOS and the decompiler native is missing — the one situation where the hint
+     * is both relevant and actionable.
+     *
+     * @param osName the {@code os.name} system property (may be null)
+     * @param decompileNativeAvailable whether Ghidra could locate the decompile native
+     * @return a populated hint message, or empty when no hint is warranted
+     */
+    public static Optional<String> hintForFailure(String osName, boolean decompileNativeAvailable) {
+        if (!isMac(osName) || decompileNativeAvailable) {
+            return Optional.empty();
+        }
+        return Optional.of(
+            "Ghidra's decompiler native binary was not found on macOS. Ghidra releases do not "
+                + "ship a prebuilt decompiler for macOS, so this is likely why decompiler tests "
+                + "are failing. Build the natives and re-run:\n"
+                + "    gradle -p \"$GHIDRA_INSTALL_DIR/support/gradle\" buildNatives");
+    }
+
+    private static boolean isMac(String osName) {
+        return osName != null && osName.toLowerCase().contains("mac");
+    }
+}

--- a/src/test/java/reva/DecompilerNativeHintTest.java
+++ b/src/test/java/reva/DecompilerNativeHintTest.java
@@ -1,0 +1,59 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reva;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Optional;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link DecompilerNativeHint}, the helper that decides whether a
+ * failing integration test should be annotated with a "run buildNatives" hint.
+ */
+public class DecompilerNativeHintTest {
+
+    @Test
+    public void macWithMissingNativeProducesBuildNativesHint() {
+        Optional<String> hint = DecompilerNativeHint.hintForFailure("Mac OS X", false);
+        assertTrue("Expected a hint on macOS when the decompile native is missing", hint.isPresent());
+        assertTrue("Hint should mention the buildNatives task", hint.get().contains("buildNatives"));
+        assertTrue("Hint should point at the Ghidra support/gradle directory",
+            hint.get().contains("support/gradle"));
+    }
+
+    @Test
+    public void macDetectionIsCaseInsensitive() {
+        assertTrue("macOS should be recognized regardless of case",
+            DecompilerNativeHint.hintForFailure("macOS", false).isPresent());
+    }
+
+    @Test
+    public void macWithNativePresentProducesNoHint() {
+        assertFalse("No hint should be emitted when the native is present",
+            DecompilerNativeHint.hintForFailure("Mac OS X", true).isPresent());
+    }
+
+    @Test
+    public void nonMacProducesNoHintEvenWhenNativeMissing() {
+        assertFalse("Linux ships prebuilt natives; no buildNatives hint there",
+            DecompilerNativeHint.hintForFailure("Linux", false).isPresent());
+        assertFalse("Windows ships prebuilt natives; no buildNatives hint there",
+            DecompilerNativeHint.hintForFailure("Windows 11", false).isPresent());
+    }
+}

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,7 +1,7 @@
 # ReVa Headless Integration Test Dependencies
 
 # PyGhidra for headless Ghidra integration
-pyghidra>=1.0.0
+pyghidra>=3.1.0
 
 # MCP SDK for proper client communication
 mcp>=1.0.0

--- a/uv.lock
+++ b/uv.lock
@@ -557,15 +557,15 @@ wheels = [
 
 [[package]]
 name = "pyghidra"
-version = "3.0.0"
+version = "3.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jpype1" },
     { name = "packaging" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/63/02/16f94ba4d32c01395d50973fe3aba1da9e9bf3551bc44364de3e8c9d71eb/pyghidra-3.0.0.tar.gz", hash = "sha256:865769da8e2575a97e2d531982039c12b9f8022d715d62e50b59fafd22be2c80", size = 51699, upload-time = "2025-12-08T18:07:33.168Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/eb/842a540cf3a8328a76636de17b0f5b3b11ac75c50a89660260f27021412a/pyghidra-3.1.0.tar.gz", hash = "sha256:2106ac131eb9a4990a79ee84dc2d39a792cf7b2d0de5eaaf1b0e6d7d2d290bb6", size = 53509, upload-time = "2026-05-14T10:00:11.403Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/40/3e/0a5e4c786a7338d9fe68998257e9624839fdb51f70063842eddb18fd1107/pyghidra-3.0.0-py3-none-any.whl", hash = "sha256:b8380b285124059c2976523dfd7eabbf619b25b65383bc636384acbd8dbc9e08", size = 50325, upload-time = "2025-12-08T18:07:32.267Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/e9/1d8f9a790be5c6d3f95a8c1428016269c0c049ae70463bc3edbc76f2bb04/pyghidra-3.1.0-py3-none-any.whl", hash = "sha256:62d76e4c42352fc38cb3a9526ba7e25681d21388c16e59a2d17e99aeaf47ac94", size = 51595, upload-time = "2026-05-14T09:59:59.323Z" },
 ]
 
 [[package]]
@@ -742,7 +742,7 @@ requires-dist = [
     { name = "httpx-sse", marker = "extra == 'test'", specifier = ">=0.4.0" },
     { name = "mcp" },
     { name = "mcp", marker = "extra == 'test'" },
-    { name = "pyghidra", specifier = ">=3.0.0" },
+    { name = "pyghidra", specifier = ">=3.1.0" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.21.0" },
     { name = "pytest-sugar", marker = "extra == 'test'", specifier = ">=0.9.0" },


### PR DESCRIPTION
## Summary

Adds support for **Ghidra 12.1** and validates the full test suite against it.

- **Serial filter factory fix** (`build.gradle`): Ghidra 12.1+ installs a global deserialization filter factory during `ApplicationConfiguration` init. Java only allows `setSerialFilterFactory()` once, before any deserialization — but Gradle test workers deserialize over their daemon socket first, locking the factory and causing `IllegalStateException: Cannot replace filter factory`. Setting `-Djdk.serialFilterFactory=ghidra.framework.remote.GhidraSerialFilterFactory` at JVM startup (on both `test` and `integrationTest`) lets Ghidra reuse it. Matches Ghidra's own `gradle/javaTestProject.gradle`.
- **CI**: add `12.1` to the test/publish matrices; build decompiler natives on macOS runners (Ghidra ships no prebuilt macOS decompiler).
- **macOS decompiler hint**: new `DecompilerNativeHint` + an integration `TestWatcher` that turns a confusing "Decompilation should not be empty" failure into an actionable "run `buildNatives`" message when the macOS decompiler native is missing.
- **deps**: bump `pyghidra` to `>=3.1.0` (pyproject, `uv.lock`, requirements, docs) to match the version shipped with Ghidra 12.1.

## Testing

Full suite green against Ghidra 12.1 (`~/.local/opt/ghidra_12.1_PUBLIC`, fresh runs verified via XML, not just `BUILD SUCCESSFUL`):

| Suite | Result |
|---|---|
| Java unit | 171 tests, 0 failures/errors |
| Java integration (18 classes, GUI, fork=1) | 125 tests, 0 failures/errors |
| Python (`pytest tests/`, e2e via PyGhidra 3.1.0) | 153 passed, 2 skipped, 0 failures/errors |

The 2 skips are intentional (GUI-only `get-current-program` / `list-open-programs` not registered in stdio mode). Also verified pyghidra 3.1.0 launches Ghidra 12.0, so the `>=3.1.0` floor is backward-compatible with the older matrix rows.

## Note for reviewers

While validating, I found that CI's "Install PyGhidra from local" step in `test-headless.yml` is effectively a no-op: the subsequent `uv run pytest` syncs the env to `uv.lock` first, reverting the manual install. So every matrix row actually tests against the locked PyPI pyghidra (now 3.1.0). It's functionally fine (3.1.0 works across versions), but if you want each row to exercise its bundled pyghidra, change `uv run pytest` → `uv run --no-sync pytest`. Left out of this PR as a separate concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)