### PR TITLE
chore(deps): combined dependabot bumps — jackson 2.22.0 + jetty 12.1.10

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -83,8 +83,8 @@ configurations {
 	// Force Jackson 2.21.x to be compatible with MCP SDK
 	all {
 		resolutionStrategy {
-			force 'com.fasterxml.jackson.core:jackson-core:2.21.4'
-			force 'com.fasterxml.jackson.core:jackson-databind:2.21.4'
+			force 'com.fasterxml.jackson.core:jackson-core:2.22.0'
+			force 'com.fasterxml.jackson.core:jackson-databind:2.22.0'
 			force 'com.fasterxml.jackson.core:jackson-annotations:2.21'
 			force 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.21.3'
 		}
@@ -113,12 +113,12 @@ dependencies {
 	implementation "io.modelcontextprotocol.sdk:mcp-json-jackson2"
 	implementation "jakarta.servlet:jakarta.servlet-api:6.1.0"
 	// Add Jetty for embedded servlet support
-	implementation "org.eclipse.jetty:jetty-server:12.1.9"
-	implementation "org.eclipse.jetty.ee10:jetty-ee10-servlet:12.1.9"
+	implementation "org.eclipse.jetty:jetty-server:12.1.10"
+	implementation "org.eclipse.jetty.ee10:jetty-ee10-servlet:12.1.10"
 
 	// Force Jackson 2.21.x to be compatible with MCP SDK
-	implementation "com.fasterxml.jackson.core:jackson-core:2.21.4"
-	implementation "com.fasterxml.jackson.core:jackson-databind:2.21.4"
+	implementation "com.fasterxml.jackson.core:jackson-core:2.22.0"
+	implementation "com.fasterxml.jackson.core:jackson-databind:2.22.0"
 	implementation "com.fasterxml.jackson.core:jackson-annotations:2.21"
 
 	// Testing dependencies


### PR DESCRIPTION
## Summary

Combines three open dependabot PRs into a single branch so CI exercises all three bumps together before they land on main:

- #311 — `com.fasterxml.jackson.core:jackson-core` / `jackson-databind` `2.21.4` → `2.22.0` (also updated in `resolutionStrategy.force`)
- #312 — `org.eclipse.jetty:jetty-server` + `org.eclipse.jetty.ee10:jetty-ee10-servlet` `12.1.9` → `12.1.10`
- #313 — `org.eclipse.jetty.ee10:jetty-ee10-servlet` `12.1.9` → `12.1.10` (fully covered by #312)

Only `build.gradle` changes. Once CI is green here, merging this PR lands all three bumps on main and the individual dependabot PRs will auto-close as their diffs are subsumed.

## Test plan

- [ ] `test-ghidra.yml` matrix (Ghidra 12.0.x + latest) — unit + integration tests
- [ ] `test-headless.yml` matrix (ubuntu + macOS × Ghidra 12.0.x + latest) — Python e2e tests via `mcp-reva`


---
_Generated by [Claude Code](https://claude.ai/code/session_01C1qfXjX7pPXmUwAFvHZHR1)_