### PR TITLE
Fix HTTP transport early session deletion

### DIFF
--- a/src/main/java/reva/server/ResilientStreamableServerTransportProvider.java
+++ b/src/main/java/reva/server/ResilientStreamableServerTransportProvider.java
@@ -17,14 +17,20 @@
 /*
  * Forked from MCP Java SDK's HttpServletStreamableServerTransportProvider (v1.1.0).
  *
- * FIX: The upstream sendMessage() catches bare Exception and unconditionally removes
- * the session from the sessions map. A serialization error on a single message
- * permanently kills the entire session. This fork splits the catch block to separate
- * serialization failures (non-fatal) from connection failures (fatal).
+ * Upstream's sendMessage() catches bare Exception and unconditionally calls
+ * sessions.remove(), so ANY failure on a single message permanently kills the whole
+ * session for the client. This fork keeps the session alive in two cases:
  *
- * No upstream issue filed yet — the bug is in HttpServletStreamableServerTransportProvider.sendMessage()
- * which catches bare Exception and unconditionally calls sessions.remove(), so any serialization
- * error permanently kills the session.
+ *   1. Serialization failures are non-fatal: a message that cannot be serialized is
+ *      logged and dropped, but the session survives.
+ *   2. A dead listening SSE stream is non-fatal: the streamable-HTTP session is keyed
+ *      by Mcp-Session-Id and is resumable across GET reconnects, so a failed write
+ *      closes only that stream and the session stays in the map. The client reconnects
+ *      with Last-Event-ID and replays. Removing the session would turn a routine
+ *      GET-stream recycle into a 404 on reconnect and a full re-initialize, dropping
+ *      every registered tool in the interim.
+ *
+ * No upstream issue filed yet.
  */
 package reva.server;
 
@@ -75,10 +81,11 @@ import reactor.core.publisher.Mono;
  *
  * <p>
  * The upstream implementation catches bare {@code Exception} in {@code sendMessage()}
- * and unconditionally removes the session, which means a single serialization error
- * permanently kills the session for ALL clients. This fork splits the catch block to
- * separate serialization failures (session stays alive) from connection failures
- * (session is properly removed).
+ * and unconditionally removes the session, so a single serialization error or a
+ * transient listening-stream write failure permanently kills the session for the
+ * client. This fork keeps the session alive in both cases: serialization failures
+ * drop only the offending message, and a failed write to the listening SSE stream
+ * closes only that stream while the session stays resumable across GET reconnects.
  *
  * @see io.modelcontextprotocol.server.transport.HttpServletStreamableServerTransportProvider
  */
@@ -627,8 +634,10 @@ public class ResilientStreamableServerTransportProvider extends HttpServlet
 	}
 
 	/**
-	 * Resilient session transport that separates serialization errors from connection
-	 * errors in sendMessage(). Serialization failures don't kill the session.
+	 * Resilient session transport for a single listening SSE stream. Neither a
+	 * serialization error nor a write failure on this stream removes the session:
+	 * serialization errors drop only the message, and a dead connection closes only
+	 * this stream, leaving the session resumable across GET reconnects.
 	 */
 	private class ResilientMcpSessionTransport implements McpStreamableServerTransport {
 
@@ -657,10 +666,11 @@ public class ResilientStreamableServerTransportProvider extends HttpServlet
 		/**
 		 * Sends a JSON-RPC message with resilient error handling.
 		 *
-		 * <p>FIX: The upstream MCP SDK catches bare Exception and removes the session
-		 * on ANY error, including serialization failures. This implementation splits
-		 * the operation: serialization errors are logged but don't kill the session,
-		 * while actual connection failures properly remove the session.
+		 * <p>The upstream MCP SDK catches bare Exception and removes the session on ANY
+		 * error. This implementation splits the operation: serialization errors are
+		 * logged and the message dropped, while a write failure closes only this
+		 * listening stream. Neither removes the session, so the client can reconnect
+		 * the GET stream (with Last-Event-ID) and resume.
 		 */
 		@Override
 		public Mono<Void> sendMessage(McpSchema.JSONRPCMessage message, String messageId) {
@@ -690,17 +700,21 @@ public class ResilientStreamableServerTransportProvider extends HttpServlet
 					}
 
 					// Step 2: Send the serialized message over the wire. If this fails,
-					// the client has actually disconnected and the session should be removed.
+					// the listening SSE connection is gone -- but the SESSION is not.
+					// Streamable-HTTP keys sessions on Mcp-Session-Id and they are
+					// resumable across GET reconnects, so close only THIS stream and
+					// leave the session in the map. Removing it would make the client's
+					// reconnect (same id) hit a 404 and force a full re-initialize,
+					// dropping every registered tool until that completes.
 					try {
 						ResilientStreamableServerTransportProvider.this.sendEvent(writer, MESSAGE_EVENT_TYPE, jsonText,
 								messageId != null ? messageId : this.sessionId);
 						logger.debug("Message sent to session {} with ID {}", this.sessionId, messageId);
 					}
 					catch (Exception e) {
-						logger.error("Failed to send message to session {}: {}",
-								this.sessionId, e.getMessage());
-						ResilientStreamableServerTransportProvider.this.sessions.remove(this.sessionId);
-						this.asyncContext.complete();
+						logger.debug("Listening stream for session {} failed to send; closing stream but keeping "
+								+ "session for reconnect: {}", this.sessionId, e.getMessage());
+						this.close();
 					}
 				}
 				finally {

--- a/src/test/java/reva/server/ResilientStreamableServerTransportProviderTest.java
+++ b/src/test/java/reva/server/ResilientStreamableServerTransportProviderTest.java
@@ -1,0 +1,172 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reva.server;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.lang.reflect.Field;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import io.modelcontextprotocol.spec.HttpHeaders;
+import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.McpStreamableServerSession;
+import jakarta.servlet.AsyncContext;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * Regression tests for the resilience fork's session lifecycle.
+ *
+ * <p>Reproduces the failure observed in the field: toggling tool groups broadcasts a
+ * burst of {@code tools/list_changed} notifications, and if one of those writes lands
+ * on a listening SSE stream whose connection the client has already recycled, the
+ * write fails. The transport must close only that stream and keep the session in the
+ * map, so the client's GET reconnect (with Last-Event-ID) resolves instead of hitting
+ * a 404 and dropping every registered tool.
+ */
+public class ResilientStreamableServerTransportProviderTest {
+
+	private static final String ENDPOINT = "/mcp/message";
+	private static final String SESSION_ID = "test-session";
+
+	private ResilientStreamableServerTransportProvider provider;
+
+	@Before
+	public void setUp() throws Exception {
+		// No keep-alive interval: avoids spinning up the scheduler thread in tests.
+		provider = ResilientStreamableServerTransportProvider.builder()
+			.mcpEndpoint(ENDPOINT)
+			.build();
+
+		// Insert a real session directly. Going through doPost(initialize) would require
+		// a wired McpServer/session factory; the session map is the only private detail
+		// we need, and a real session exercises the genuine notify -> listeningStream ->
+		// transport.sendMessage path that the broadcast travels.
+		McpStreamableServerSession session = new McpStreamableServerSession(SESSION_ID, null, null,
+				Duration.ofSeconds(1), new HashMap<>(), new HashMap<>());
+		sessions(provider).put(SESSION_ID, session);
+	}
+
+	@Test
+	public void brokenListeningStreamWriteKeepsSessionAlive() throws Exception {
+		// Establish the listening SSE stream over a writer whose connection is dead.
+		AsyncContext asyncContext = establishListeningStream(failingWriter());
+
+		// Broadcast as a tool toggle would: write fails on the dead connection.
+		provider.notifyClients(McpSchema.METHOD_NOTIFICATION_TOOLS_LIST_CHANGED, null).block();
+
+		// The session must survive — only the stream is gone.
+		assertTrue("Session must remain after a listening-stream write failure",
+				sessions(provider).containsKey(SESSION_ID));
+		// The dead stream's async context is completed (stream closed, not leaked).
+		verify(asyncContext, atLeastOnce()).complete();
+	}
+
+	@Test
+	public void sessionSurvivesBrokenStreamSoGetReconnectResolves() throws Exception {
+		// First GET establishes a stream that then fails on broadcast.
+		establishListeningStream(failingWriter());
+		provider.notifyClients(McpSchema.METHOD_NOTIFICATION_TOOLS_LIST_CHANGED, null).block();
+
+		// Client reconnects the GET stream with Last-Event-ID to resume.
+		HttpServletResponse reconnect = mock(HttpServletResponse.class);
+		when(reconnect.getWriter()).thenReturn(new PrintWriter(new StringWriter()));
+		AsyncContext reconnectAsync = mock(AsyncContext.class);
+		HttpServletRequest reconnectRequest = getRequest(reconnectAsync);
+		when(reconnectRequest.getHeader(HttpHeaders.LAST_EVENT_ID)).thenReturn("5");
+
+		provider.doGet(reconnectRequest, reconnect);
+
+		// Reconnect resolved: the session was found, so no error response of any kind
+		// (neither sendError overload) and the stream re-opened.
+		verify(reconnect, never()).sendError(eq(HttpServletResponse.SC_NOT_FOUND));
+		verify(reconnect, never()).sendError(anyInt());
+		verify(reconnect, never()).sendError(anyInt(), anyString());
+		verify(reconnectRequest).startAsync();
+	}
+
+	// --- helpers ---------------------------------------------------------------
+
+	/** Drives doGet to attach a listening stream backed by the given writer. */
+	private AsyncContext establishListeningStream(PrintWriter writer) throws Exception {
+		HttpServletResponse response = mock(HttpServletResponse.class);
+		when(response.getWriter()).thenReturn(writer);
+		AsyncContext asyncContext = mock(AsyncContext.class);
+		HttpServletRequest request = getRequest(asyncContext);
+		// Fresh listening stream (no replay).
+		when(request.getHeader(HttpHeaders.LAST_EVENT_ID)).thenReturn(null);
+
+		provider.doGet(request, response);
+		return asyncContext;
+	}
+
+	/** A mock GET request for our session, returning the given async context. */
+	private HttpServletRequest getRequest(AsyncContext asyncContext) {
+		HttpServletRequest request = mock(HttpServletRequest.class);
+		when(request.getRequestURI()).thenReturn(ENDPOINT);
+		when(request.getHeader("Accept")).thenReturn("text/event-stream, application/json");
+		when(request.getHeader(HttpHeaders.MCP_SESSION_ID)).thenReturn(SESSION_ID);
+		when(request.getHeaderNames()).thenReturn(Collections.enumeration(Collections.emptyList()));
+		when(request.startAsync()).thenReturn(asyncContext);
+		return request;
+	}
+
+	/** A PrintWriter whose underlying connection is dead: every write trips checkError(). */
+	private static PrintWriter failingWriter() {
+		Writer dead = new Writer() {
+			@Override
+			public void write(char[] cbuf, int off, int len) throws IOException {
+				throw new IOException("client disconnected");
+			}
+
+			@Override
+			public void flush() throws IOException {
+				throw new IOException("client disconnected");
+			}
+
+			@Override
+			public void close() {
+			}
+		};
+		return new PrintWriter(dead);
+	}
+
+	@SuppressWarnings("unchecked")
+	private static Map<String, McpStreamableServerSession> sessions(
+			ResilientStreamableServerTransportProvider provider) throws Exception {
+		Field field = ResilientStreamableServerTransportProvider.class.getDeclaredField("sessions");
+		field.setAccessible(true);
+		return (Map<String, McpStreamableServerSession>) field.get(provider);
+	}
+}


### PR DESCRIPTION
The upstream MCP HTTP transport deletes sessions in normal cases. This breaks tool reloading.