### PR TITLE
chore(deps): combined dependabot updates (actions/checkout v7, setup-ghidra v2.1.3)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -25,7 +25,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Install Ghidra
         # Sets GHIDRA_INSTALL_DIR for subsequent steps and the agent session.
-        uses: antoniovazquezblanco/setup-ghidra@v2.1.2
+        uses: antoniovazquezblanco/setup-ghidra@v2.1.3
         with:
           version: "latest"
           auth_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -28,7 +28,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           lfs: true
 

--- a/.github/workflows/publish-ghidra.yml
+++ b/.github/workflows/publish-ghidra.yml
@@ -34,7 +34,7 @@ jobs:
         java-version: "21"
         distribution: "microsoft"
     - name: Install Ghidra 🐉
-      uses: antoniovazquezblanco/setup-ghidra@v2.1.2
+      uses: antoniovazquezblanco/setup-ghidra@v2.1.3
       with:
         version: ${{ matrix.ghidra-version }}
         auth_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-ghidra.yml
+++ b/.github/workflows/publish-ghidra.yml
@@ -27,7 +27,7 @@ jobs:
     name: Build distribution 📦
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - name: Set up Java 🍵
       uses: actions/setup-java@v5
       with:

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -22,7 +22,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           # Fetch all history for setuptools_scm to determine version from git tags
           fetch-depth: 0

--- a/.github/workflows/test-ghidra.yml
+++ b/.github/workflows/test-ghidra.yml
@@ -40,7 +40,7 @@ jobs:
         distribution: "microsoft"
 
     - name: Install Ghidra 🐉
-      uses: antoniovazquezblanco/setup-ghidra@v2.1.2
+      uses: antoniovazquezblanco/setup-ghidra@v2.1.3
       with:
         version: ${{ matrix.ghidra-version }}
         auth_token: ${{ secrets.GITHUB_TOKEN }}
@@ -105,7 +105,7 @@ jobs:
         distribution: "microsoft"
 
     - name: Install Ghidra 🐉
-      uses: antoniovazquezblanco/setup-ghidra@v2.1.2
+      uses: antoniovazquezblanco/setup-ghidra@v2.1.3
       with:
         version: "latest"
         auth_token: ${{ secrets.GITHUB_TOKEN }}
@@ -156,7 +156,7 @@ jobs:
         queries: security-extended,security-and-quality
 
     - name: Install Ghidra 🐉
-      uses: antoniovazquezblanco/setup-ghidra@v2.1.2
+      uses: antoniovazquezblanco/setup-ghidra@v2.1.3
       with:
         version: "latest"
         auth_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-ghidra.yml
+++ b/.github/workflows/test-ghidra.yml
@@ -29,7 +29,7 @@ jobs:
     name: Test on Ghidra ${{ matrix.ghidra-version }}
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
       with:
         lfs: true
 
@@ -94,7 +94,7 @@ jobs:
     name: Lint and Check 🔍
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
       with:
         lfs: true
 
@@ -138,7 +138,7 @@ jobs:
       security-events: write
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
       with:
         lfs: true
 

--- a/.github/workflows/test-headless.yml
+++ b/.github/workflows/test-headless.yml
@@ -63,7 +63,7 @@ jobs:
         python-version: "3.10"
 
     - name: Install Ghidra ${{ matrix.ghidra-version }}
-      uses: antoniovazquezblanco/setup-ghidra@v2.1.2
+      uses: antoniovazquezblanco/setup-ghidra@v2.1.3
       with:
         version: ${{ matrix.ghidra-version }}
         auth_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-headless.yml
+++ b/.github/workflows/test-headless.yml
@@ -47,7 +47,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         lfs: true
 


### PR DESCRIPTION
Combines the two open dependabot PRs into one branch so the full CI matrix runs against both updates together before merging to main.

## Combined updates

- `actions/checkout`: v6 → v7 (supersedes #324)
- `antoniovazquezblanco/setup-ghidra`: v2.1.2 → v2.1.3 (supersedes #323)

Both diffs touch only `.github/workflows/*.yml` and merged cleanly with no conflicts. Each individual PR already had all 21 checks (Lint, CodeQL, Ghidra 12.0–12.1 matrix on ubuntu+macos, headless) passing — this PR re-runs them with both bumps applied together.

## Test plan

- [ ] All Ghidra test matrix jobs pass on the combined branch
- [ ] CodeQL passes
- [ ] Lint and Check passes
- [ ] Test on headless passes
- [ ] copilot-setup-steps job passes
- [ ] If green, merge to main (closes #323 and #324)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q6TACtjE8UBNHg7ebvZqG9)_