### PR TITLE
chore(deps): combine Jackson 2.22.1 + Jetty 12.1.11 dependabot updates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -83,10 +83,10 @@ configurations {
 	// Force Jackson 2.21.x to be compatible with MCP SDK
 	all {
 		resolutionStrategy {
-			force 'com.fasterxml.jackson.core:jackson-core:2.22.0'
-			force 'com.fasterxml.jackson.core:jackson-databind:2.22.0'
+			force 'com.fasterxml.jackson.core:jackson-core:2.22.1'
+			force 'com.fasterxml.jackson.core:jackson-databind:2.22.1'
 			force 'com.fasterxml.jackson.core:jackson-annotations:2.21'
-			force 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.21.3'
+			force 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.22.1'
 		}
 	}
 }
@@ -113,12 +113,12 @@ dependencies {
 	implementation "io.modelcontextprotocol.sdk:mcp-json-jackson2"
 	implementation "jakarta.servlet:jakarta.servlet-api:6.1.0"
 	// Add Jetty for embedded servlet support
-	implementation "org.eclipse.jetty:jetty-server:12.1.10"
-	implementation "org.eclipse.jetty.ee10:jetty-ee10-servlet:12.1.10"
+	implementation "org.eclipse.jetty:jetty-server:12.1.11"
+	implementation "org.eclipse.jetty.ee10:jetty-ee10-servlet:12.1.11"
 
 	// Force Jackson 2.21.x to be compatible with MCP SDK
-	implementation "com.fasterxml.jackson.core:jackson-core:2.22.0"
-	implementation "com.fasterxml.jackson.core:jackson-databind:2.22.0"
+	implementation "com.fasterxml.jackson.core:jackson-core:2.22.1"
+	implementation "com.fasterxml.jackson.core:jackson-databind:2.22.1"
 	implementation "com.fasterxml.jackson.core:jackson-annotations:2.21"
 
 	// Testing dependencies


### PR DESCRIPTION
## Summary

Combines the five open dependabot dependency updates into a single branch so CI runs the whole set together (cheaper matrix run, and any interaction between the bumps is caught before merge). All are patch bumps within the same major line — no API changes expected.

- `com.fasterxml.jackson.core:jackson-core` 2.22.0 → 2.22.1 (supersedes #333)
- `com.fasterxml.jackson.core:jackson-databind` 2.22.0 → 2.22.1 (supersedes #332)
- `com.fasterxml.jackson.dataformat:jackson-dataformat-yaml` 2.21.3 → 2.22.1 (supersedes #334)
- `org.eclipse.jetty:jetty-server` 12.1.10 → 12.1.11 (supersedes #331)
- `org.eclipse.jetty.ee10:jetty-ee10-servlet` 12.1.10 → 12.1.11 (supersedes #330)

Only `build.gradle` changes; both the `force` block and the direct `implementation` declarations move to the new versions to keep the Jackson resolution strategy consistent with the MCP SDK requirement noted in the file.

## Test plan

- [ ] `Test Ghidra 🐉 Extension` matrix passes on all 7 Ghidra versions (unit + integration tests).
- [ ] `Test Headless Mode 🤖` matrix passes on Ubuntu × 7 Ghidra versions and macOS × latest/12.0 (end-to-end Python + PyGhidra).
- [ ] CodeQL analysis green.
- [ ] Once green, merge to `main` and close #330–#334 as superseded.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EV6QJaVBbdqcdNaqDx3EvP)_