### PR TITLE
chore(deps): combined dependabot updates - gradle/actions 6.2.0, sigstore 3.5.0

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -65,7 +65,7 @@ jobs:
           auth_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@v6.2.0
         with:
           gradle-version: "8.14"
 

--- a/.github/workflows/publish-ghidra.yml
+++ b/.github/workflows/publish-ghidra.yml
@@ -67,7 +67,7 @@ jobs:
         merge-multiple: true
 
     - name: Sign the dists with Sigstore
-      uses: sigstore/gh-action-sigstore-python@v3.4.0
+      uses: sigstore/gh-action-sigstore-python@v3.5.0
       with:
         inputs: >-
           ./dist/*.zip

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -104,7 +104,7 @@ jobs:
           path: dist/
 
       - name: Sign distributions with Sigstore
-        uses: sigstore/gh-action-sigstore-python@v3.4.0
+        uses: sigstore/gh-action-sigstore-python@v3.5.0
         with:
           inputs: >-
             ./dist/*.tar.gz

--- a/.github/workflows/test-ghidra.yml
+++ b/.github/workflows/test-ghidra.yml
@@ -53,7 +53,7 @@ jobs:
 
 
     - name: Setup Gradle 🔧
-      uses: gradle/actions/setup-gradle@v6
+      uses: gradle/actions/setup-gradle@v6.2.0
       with:
         gradle-version: "8.14"
 
@@ -117,7 +117,7 @@ jobs:
         echo "DISPLAY=:99" >> $GITHUB_ENV
 
     - name: Setup Gradle 🔧
-      uses: gradle/actions/setup-gradle@v6
+      uses: gradle/actions/setup-gradle@v6.2.0
       with:
         gradle-version: "8.14"
         dependency-graph: generate-and-submit
@@ -162,7 +162,7 @@ jobs:
         auth_token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Setup Gradle for CodeQL 🔧
-      uses: gradle/actions/setup-gradle@v6
+      uses: gradle/actions/setup-gradle@v6.2.0
       with:
         gradle-version: "8.14"
 

--- a/.github/workflows/test-headless.yml
+++ b/.github/workflows/test-headless.yml
@@ -69,7 +69,7 @@ jobs:
         auth_token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v6
+      uses: gradle/actions/setup-gradle@v6.2.0
       with:
         gradle-version: "8.14"
 


### PR DESCRIPTION
## Summary

Combines the two open dependabot dependency updates into a single branch so the full CI/E2E suite exercises them together before landing on `main`.

- #339 — `gradle/actions` from `v6` to `v6.2.0` (affects `copilot-setup-steps.yml`, `test-ghidra.yml`, `test-headless.yml`)
- #338 — `sigstore/gh-action-sigstore-python` from `v3.4.0` to `v3.5.0` (affects `publish-ghidra.yml`, `publish-pypi.yml`)

The two PRs touch disjoint workflow files; the merges were clean with no conflicts. Both individual PRs are already green in CI on their own.

## Test plan

- [ ] `Test Ghidra 🐉 Extension` workflow passes on all matrix versions
- [ ] `Test Headless Mode 🤖` workflow passes on all matrix versions
- [ ] `Lint and Check 🔍` passes
- [ ] `CodeQL Security Analysis 🔒` passes
- [ ] Once green, merge here and close #338 / #339

---
_Generated by [Claude Code](https://claude.ai/code/session_01AdQaxK6sUZejijw3nosQTF)_