### PR TITLE
chore(deps): combined dependabot updates — jetty 12.1.12, gradle/actions 6.2.0, sigstore 3.5.0

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -65,7 +65,7 @@ jobs:
           auth_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@v6.2.0
         with:
           gradle-version: "8.14"
 

--- a/.github/workflows/publish-ghidra.yml
+++ b/.github/workflows/publish-ghidra.yml
@@ -67,7 +67,7 @@ jobs:
         merge-multiple: true
 
     - name: Sign the dists with Sigstore
-      uses: sigstore/gh-action-sigstore-python@v3.4.0
+      uses: sigstore/gh-action-sigstore-python@v3.5.0
       with:
         inputs: >-
           ./dist/*.zip

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -104,7 +104,7 @@ jobs:
           path: dist/
 
       - name: Sign distributions with Sigstore
-        uses: sigstore/gh-action-sigstore-python@v3.4.0
+        uses: sigstore/gh-action-sigstore-python@v3.5.0
         with:
           inputs: >-
             ./dist/*.tar.gz

--- a/.github/workflows/test-ghidra.yml
+++ b/.github/workflows/test-ghidra.yml
@@ -53,7 +53,7 @@ jobs:
 
 
     - name: Setup Gradle 🔧
-      uses: gradle/actions/setup-gradle@v6
+      uses: gradle/actions/setup-gradle@v6.2.0
       with:
         gradle-version: "8.14"
 
@@ -117,7 +117,7 @@ jobs:
         echo "DISPLAY=:99" >> $GITHUB_ENV
 
     - name: Setup Gradle 🔧
-      uses: gradle/actions/setup-gradle@v6
+      uses: gradle/actions/setup-gradle@v6.2.0
       with:
         gradle-version: "8.14"
         dependency-graph: generate-and-submit
@@ -162,7 +162,7 @@ jobs:
         auth_token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Setup Gradle for CodeQL 🔧
-      uses: gradle/actions/setup-gradle@v6
+      uses: gradle/actions/setup-gradle@v6.2.0
       with:
         gradle-version: "8.14"
 

--- a/.github/workflows/test-headless.yml
+++ b/.github/workflows/test-headless.yml
@@ -69,7 +69,7 @@ jobs:
         auth_token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v6
+      uses: gradle/actions/setup-gradle@v6.2.0
       with:
         gradle-version: "8.14"
 

--- a/build.gradle
+++ b/build.gradle
@@ -113,8 +113,8 @@ dependencies {
 	implementation "io.modelcontextprotocol.sdk:mcp-json-jackson2"
 	implementation "jakarta.servlet:jakarta.servlet-api:6.1.0"
 	// Add Jetty for embedded servlet support
-	implementation "org.eclipse.jetty:jetty-server:12.1.11"
-	implementation "org.eclipse.jetty.ee10:jetty-ee10-servlet:12.1.11"
+	implementation "org.eclipse.jetty:jetty-server:12.1.12"
+	implementation "org.eclipse.jetty.ee10:jetty-ee10-servlet:12.1.12"
 
 	// Force Jackson 2.21.x to be compatible with MCP SDK
 	implementation "com.fasterxml.jackson.core:jackson-core:2.22.1"

--- a/build.gradle
+++ b/build.gradle
@@ -114,7 +114,7 @@ dependencies {
 	implementation "jakarta.servlet:jakarta.servlet-api:6.1.0"
 	// Add Jetty for embedded servlet support
 	implementation "org.eclipse.jetty:jetty-server:12.1.11"
-	implementation "org.eclipse.jetty.ee10:jetty-ee10-servlet:12.1.11"
+	implementation "org.eclipse.jetty.ee10:jetty-ee10-servlet:12.1.12"
 
 	// Force Jackson 2.21.x to be compatible with MCP SDK
 	implementation "com.fasterxml.jackson.core:jackson-core:2.22.1"


### PR DESCRIPTION
## Summary

Combines the four open dependabot dependency updates into a single branch so the full CI/E2E suite exercises them together before landing on `main`. Supersedes #340 (which only covered the first two).

- #339 — `gradle/actions` from `v6` to `v6.2.0` (`copilot-setup-steps.yml`, `test-ghidra.yml`, `test-headless.yml`)
- #338 — `sigstore/gh-action-sigstore-python` from `v3.4.0` to `v3.5.0` (`publish-ghidra.yml`, `publish-pypi.yml`)
- #341 — `org.eclipse.jetty:jetty-server` from `12.1.11` to `12.1.12` (`build.gradle`)
- #342 — `org.eclipse.jetty.ee10:jetty-ee10-servlet` from `12.1.11` to `12.1.12` (`build.gradle`)

The four dependabot branches merged with a single trivial conflict on the two adjacent Jetty lines in `build.gradle`, resolved to take both 12.1.12 bumps. All other merges were clean. Total diff: 6 files, 9 lines each way.

## Test plan

- [ ] `Test Ghidra 🐉 Extension` workflow passes on the full matrix
- [ ] `Test Headless Mode 🤖` workflow passes on the full matrix
- [ ] `Lint and Check 🔍` passes
- [ ] `CodeQL Security Analysis 🔒` passes
- [ ] Once green, merge here and close #338 / #339 / #340 / #341 / #342 as superseded

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSEFYK9rordiXHGXfuVRVP)_