### PR TITLE
chore(deps): combined dependabot updates — Jackson 2.22.2, mcp-bom 2.0.1, setup-ghidra 2.1.5, gradle/actions 6.3.0

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -65,7 +65,7 @@ jobs:
           auth_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6.2.0
+        uses: gradle/actions/setup-gradle@v6.3.0
         with:
           gradle-version: "8.14"
 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Install Ghidra
         # Sets GHIDRA_INSTALL_DIR for subsequent steps and the agent session.
-        uses: antoniovazquezblanco/setup-ghidra@v2.1.4
+        uses: antoniovazquezblanco/setup-ghidra@v2.1.5
         with:
           version: "latest"
           auth_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-ghidra.yml
+++ b/.github/workflows/publish-ghidra.yml
@@ -34,7 +34,7 @@ jobs:
         java-version: "21"
         distribution: "microsoft"
     - name: Install Ghidra 🐉
-      uses: antoniovazquezblanco/setup-ghidra@v2.1.4
+      uses: antoniovazquezblanco/setup-ghidra@v2.1.5
       with:
         version: ${{ matrix.ghidra-version }}
         auth_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-ghidra.yml
+++ b/.github/workflows/test-ghidra.yml
@@ -53,7 +53,7 @@ jobs:
 
 
     - name: Setup Gradle 🔧
-      uses: gradle/actions/setup-gradle@v6.2.0
+      uses: gradle/actions/setup-gradle@v6.3.0
       with:
         gradle-version: "8.14"
 
@@ -117,7 +117,7 @@ jobs:
         echo "DISPLAY=:99" >> $GITHUB_ENV
 
     - name: Setup Gradle 🔧
-      uses: gradle/actions/setup-gradle@v6.2.0
+      uses: gradle/actions/setup-gradle@v6.3.0
       with:
         gradle-version: "8.14"
         dependency-graph: generate-and-submit
@@ -162,7 +162,7 @@ jobs:
         auth_token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Setup Gradle for CodeQL 🔧
-      uses: gradle/actions/setup-gradle@v6.2.0
+      uses: gradle/actions/setup-gradle@v6.3.0
       with:
         gradle-version: "8.14"
 

--- a/.github/workflows/test-ghidra.yml
+++ b/.github/workflows/test-ghidra.yml
@@ -40,7 +40,7 @@ jobs:
         distribution: "microsoft"
 
     - name: Install Ghidra 🐉
-      uses: antoniovazquezblanco/setup-ghidra@v2.1.4
+      uses: antoniovazquezblanco/setup-ghidra@v2.1.5
       with:
         version: ${{ matrix.ghidra-version }}
         auth_token: ${{ secrets.GITHUB_TOKEN }}
@@ -105,7 +105,7 @@ jobs:
         distribution: "microsoft"
 
     - name: Install Ghidra 🐉
-      uses: antoniovazquezblanco/setup-ghidra@v2.1.4
+      uses: antoniovazquezblanco/setup-ghidra@v2.1.5
       with:
         version: "latest"
         auth_token: ${{ secrets.GITHUB_TOKEN }}
@@ -156,7 +156,7 @@ jobs:
         queries: security-extended,security-and-quality
 
     - name: Install Ghidra 🐉
-      uses: antoniovazquezblanco/setup-ghidra@v2.1.4
+      uses: antoniovazquezblanco/setup-ghidra@v2.1.5
       with:
         version: "latest"
         auth_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-headless.yml
+++ b/.github/workflows/test-headless.yml
@@ -63,7 +63,7 @@ jobs:
         python-version: "3.10"
 
     - name: Install Ghidra ${{ matrix.ghidra-version }}
-      uses: antoniovazquezblanco/setup-ghidra@v2.1.4
+      uses: antoniovazquezblanco/setup-ghidra@v2.1.5
       with:
         version: ${{ matrix.ghidra-version }}
         auth_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-headless.yml
+++ b/.github/workflows/test-headless.yml
@@ -69,7 +69,7 @@ jobs:
         auth_token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v6.2.0
+      uses: gradle/actions/setup-gradle@v6.3.0
       with:
         gradle-version: "8.14"
 

--- a/build.gradle
+++ b/build.gradle
@@ -108,7 +108,7 @@ repositories {
 dependencies {
 	// Any external dependencies added here will automatically be copied to the lib/ directory when
 	// this extension is built.
-	implementation platform("io.modelcontextprotocol.sdk:mcp-bom:2.0.0")
+	implementation platform("io.modelcontextprotocol.sdk:mcp-bom:2.0.1")
 	implementation "io.modelcontextprotocol.sdk:mcp-core"
 	implementation "io.modelcontextprotocol.sdk:mcp-json-jackson2"
 	implementation "jakarta.servlet:jakarta.servlet-api:6.1.0"

--- a/build.gradle
+++ b/build.gradle
@@ -83,8 +83,8 @@ configurations {
 	// Force Jackson 2.21.x to be compatible with MCP SDK
 	all {
 		resolutionStrategy {
-			force 'com.fasterxml.jackson.core:jackson-core:2.22.1'
-			force 'com.fasterxml.jackson.core:jackson-databind:2.22.1'
+			force 'com.fasterxml.jackson.core:jackson-core:2.22.2'
+			force 'com.fasterxml.jackson.core:jackson-databind:2.22.2'
 			force 'com.fasterxml.jackson.core:jackson-annotations:2.21'
 			force 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.22.1'
 		}
@@ -117,8 +117,8 @@ dependencies {
 	implementation "org.eclipse.jetty.ee10:jetty-ee10-servlet:12.1.12"
 
 	// Force Jackson 2.21.x to be compatible with MCP SDK
-	implementation "com.fasterxml.jackson.core:jackson-core:2.22.1"
-	implementation "com.fasterxml.jackson.core:jackson-databind:2.22.1"
+	implementation "com.fasterxml.jackson.core:jackson-core:2.22.2"
+	implementation "com.fasterxml.jackson.core:jackson-databind:2.22.2"
 	implementation "com.fasterxml.jackson.core:jackson-annotations:2.21"
 
 	// Testing dependencies

--- a/build.gradle
+++ b/build.gradle
@@ -86,7 +86,7 @@ configurations {
 			force 'com.fasterxml.jackson.core:jackson-core:2.22.1'
 			force 'com.fasterxml.jackson.core:jackson-databind:2.22.1'
 			force 'com.fasterxml.jackson.core:jackson-annotations:2.21'
-			force 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.22.1'
+			force 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.22.2'
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Combined merge of open dependabot PRs so CI runs against them together instead of six separate CI runs.

Includes:
- #344 `io.modelcontextprotocol.sdk:mcp-bom` 2.0.0 → 2.0.1
- #345 `com.fasterxml.jackson.dataformat:jackson-dataformat-yaml` 2.22.1 → 2.22.2 (resolutionStrategy `force`)
- #346 `com.fasterxml.jackson.core:jackson-databind` 2.22.1 → 2.22.2 (both `force` and `implementation`)
- #347 `com.fasterxml.jackson.core:jackson-core` 2.22.1 → 2.22.2 (both `force` and `implementation`)
- #348 `gradle/actions/setup-gradle` v6.2.0 → v6.3.0 (workflow files)
- #349 `antoniovazquezblanco/setup-ghidra` v2.1.4 → v2.1.5 (workflow files)

Follows the pattern from #343.

## Test plan

- [x] Python unit tests (`uv run pytest -m unit`) pass locally
- [ ] `gradle test` — Java unit tests
- [ ] `gradle integrationTest` — Java integration tests
- [ ] `uv run pytest` — Python unit, integration, and e2e tests (via `test-headless.yml`)

Java tests and PyGhidra-backed tests require a real Ghidra install and will be validated in CI, which is the point of this combined branch.

---
_Generated by [Claude Code](https://claude.ai/code/session_0179unscHU7wgmrmQz5YYhFR)_