### PR TITLE
chore(deps): combined dependabot updates — Jackson 2.22.2, mcp-bom 2.0.1, setup-ghidra 2.1.6, gradle/actions 6.3.0, setup-java v6

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -47,7 +47,7 @@ jobs:
           clang --version
 
       - name: Set up Java 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           java-version: "21"
           distribution: "microsoft"
@@ -59,13 +59,13 @@ jobs:
 
       - name: Install Ghidra
         # Sets GHIDRA_INSTALL_DIR for subsequent steps and the agent session.
-        uses: antoniovazquezblanco/setup-ghidra@v2.1.4
+        uses: antoniovazquezblanco/setup-ghidra@v2.1.5
         with:
           version: "latest"
           auth_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6.2.0
+        uses: gradle/actions/setup-gradle@v6.3.0
         with:
           gradle-version: "8.14"
 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Install Ghidra
         # Sets GHIDRA_INSTALL_DIR for subsequent steps and the agent session.
-        uses: antoniovazquezblanco/setup-ghidra@v2.1.5
+        uses: antoniovazquezblanco/setup-ghidra@v2.1.6
         with:
           version: "latest"
           auth_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-ghidra.yml
+++ b/.github/workflows/publish-ghidra.yml
@@ -30,7 +30,7 @@ jobs:
         java-version: "21"
         distribution: "microsoft"
     - name: Install Ghidra 🐉
-      uses: antoniovazquezblanco/setup-ghidra@v2.1.5
+      uses: antoniovazquezblanco/setup-ghidra@v2.1.6
       with:
         version: ${{ matrix.ghidra-version }}
         auth_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-ghidra.yml
+++ b/.github/workflows/publish-ghidra.yml
@@ -25,12 +25,12 @@ jobs:
     steps:
     - uses: actions/checkout@v7
     - name: Set up Java 🍵
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@v6
       with:
         java-version: "21"
         distribution: "microsoft"
     - name: Install Ghidra 🐉
-      uses: antoniovazquezblanco/setup-ghidra@v2.1.4
+      uses: antoniovazquezblanco/setup-ghidra@v2.1.5
       with:
         version: ${{ matrix.ghidra-version }}
         auth_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-ghidra.yml
+++ b/.github/workflows/test-ghidra.yml
@@ -36,7 +36,7 @@ jobs:
         distribution: "microsoft"
 
     - name: Install Ghidra 🐉
-      uses: antoniovazquezblanco/setup-ghidra@v2.1.5
+      uses: antoniovazquezblanco/setup-ghidra@v2.1.6
       with:
         version: ${{ matrix.ghidra-version }}
         auth_token: ${{ secrets.GITHUB_TOKEN }}
@@ -101,7 +101,7 @@ jobs:
         distribution: "microsoft"
 
     - name: Install Ghidra 🐉
-      uses: antoniovazquezblanco/setup-ghidra@v2.1.5
+      uses: antoniovazquezblanco/setup-ghidra@v2.1.6
       with:
         version: "latest"
         auth_token: ${{ secrets.GITHUB_TOKEN }}
@@ -152,7 +152,7 @@ jobs:
         queries: security-extended,security-and-quality
 
     - name: Install Ghidra 🐉
-      uses: antoniovazquezblanco/setup-ghidra@v2.1.5
+      uses: antoniovazquezblanco/setup-ghidra@v2.1.6
       with:
         version: "latest"
         auth_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-ghidra.yml
+++ b/.github/workflows/test-ghidra.yml
@@ -30,13 +30,13 @@ jobs:
         lfs: true
 
     - name: Set up Java 🍵
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@v6
       with:
         java-version: "21"
         distribution: "microsoft"
 
     - name: Install Ghidra 🐉
-      uses: antoniovazquezblanco/setup-ghidra@v2.1.4
+      uses: antoniovazquezblanco/setup-ghidra@v2.1.5
       with:
         version: ${{ matrix.ghidra-version }}
         auth_token: ${{ secrets.GITHUB_TOKEN }}
@@ -49,7 +49,7 @@ jobs:
 
 
     - name: Setup Gradle 🔧
-      uses: gradle/actions/setup-gradle@v6.2.0
+      uses: gradle/actions/setup-gradle@v6.3.0
       with:
         gradle-version: "8.14"
 
@@ -95,13 +95,13 @@ jobs:
         lfs: true
 
     - name: Set up Java 🍵
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@v6
       with:
         java-version: "21"
         distribution: "microsoft"
 
     - name: Install Ghidra 🐉
-      uses: antoniovazquezblanco/setup-ghidra@v2.1.4
+      uses: antoniovazquezblanco/setup-ghidra@v2.1.5
       with:
         version: "latest"
         auth_token: ${{ secrets.GITHUB_TOKEN }}
@@ -113,7 +113,7 @@ jobs:
         echo "DISPLAY=:99" >> $GITHUB_ENV
 
     - name: Setup Gradle 🔧
-      uses: gradle/actions/setup-gradle@v6.2.0
+      uses: gradle/actions/setup-gradle@v6.3.0
       with:
         gradle-version: "8.14"
         dependency-graph: generate-and-submit
@@ -139,7 +139,7 @@ jobs:
         lfs: true
 
     - name: Set up Java 🍵
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@v6
       with:
         java-version: "21"
         distribution: "microsoft"
@@ -152,13 +152,13 @@ jobs:
         queries: security-extended,security-and-quality
 
     - name: Install Ghidra 🐉
-      uses: antoniovazquezblanco/setup-ghidra@v2.1.4
+      uses: antoniovazquezblanco/setup-ghidra@v2.1.5
       with:
         version: "latest"
         auth_token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Setup Gradle for CodeQL 🔧
-      uses: gradle/actions/setup-gradle@v6.2.0
+      uses: gradle/actions/setup-gradle@v6.3.0
       with:
         gradle-version: "8.14"
 

--- a/.github/workflows/test-headless.yml
+++ b/.github/workflows/test-headless.yml
@@ -49,7 +49,7 @@ jobs:
         lfs: true
 
     - name: Set up Java 21
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@v6
       with:
         java-version: "21"
         distribution: "microsoft"
@@ -60,13 +60,13 @@ jobs:
         python-version: "3.10"
 
     - name: Install Ghidra ${{ matrix.ghidra-version }}
-      uses: antoniovazquezblanco/setup-ghidra@v2.1.4
+      uses: antoniovazquezblanco/setup-ghidra@v2.1.5
       with:
         version: ${{ matrix.ghidra-version }}
         auth_token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v6.2.0
+      uses: gradle/actions/setup-gradle@v6.3.0
       with:
         gradle-version: "8.14"
 

--- a/.github/workflows/test-headless.yml
+++ b/.github/workflows/test-headless.yml
@@ -60,7 +60,7 @@ jobs:
         python-version: "3.10"
 
     - name: Install Ghidra ${{ matrix.ghidra-version }}
-      uses: antoniovazquezblanco/setup-ghidra@v2.1.5
+      uses: antoniovazquezblanco/setup-ghidra@v2.1.6
       with:
         version: ${{ matrix.ghidra-version }}
         auth_token: ${{ secrets.GITHUB_TOKEN }}

--- a/build.gradle
+++ b/build.gradle
@@ -83,10 +83,10 @@ configurations {
 	// Force Jackson 2.21.x to be compatible with MCP SDK
 	all {
 		resolutionStrategy {
-			force 'com.fasterxml.jackson.core:jackson-core:2.22.1'
-			force 'com.fasterxml.jackson.core:jackson-databind:2.22.1'
+			force 'com.fasterxml.jackson.core:jackson-core:2.22.2'
+			force 'com.fasterxml.jackson.core:jackson-databind:2.22.2'
 			force 'com.fasterxml.jackson.core:jackson-annotations:2.21'
-			force 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.22.1'
+			force 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.22.2'
 		}
 	}
 }
@@ -108,7 +108,7 @@ repositories {
 dependencies {
 	// Any external dependencies added here will automatically be copied to the lib/ directory when
 	// this extension is built.
-	implementation platform("io.modelcontextprotocol.sdk:mcp-bom:2.0.0")
+	implementation platform("io.modelcontextprotocol.sdk:mcp-bom:2.0.1")
 	implementation "io.modelcontextprotocol.sdk:mcp-core"
 	implementation "io.modelcontextprotocol.sdk:mcp-json-jackson2"
 	implementation "jakarta.servlet:jakarta.servlet-api:6.1.0"
@@ -117,8 +117,8 @@ dependencies {
 	implementation "org.eclipse.jetty.ee10:jetty-ee10-servlet:12.1.12"
 
 	// Force Jackson 2.21.x to be compatible with MCP SDK
-	implementation "com.fasterxml.jackson.core:jackson-core:2.22.1"
-	implementation "com.fasterxml.jackson.core:jackson-databind:2.22.1"
+	implementation "com.fasterxml.jackson.core:jackson-core:2.22.2"
+	implementation "com.fasterxml.jackson.core:jackson-databind:2.22.2"
 	implementation "com.fasterxml.jackson.core:jackson-annotations:2.21"
 
 	// Testing dependencies


### PR DESCRIPTION
## Summary

Combined merge of the currently-open dependabot PRs, rebased onto the latest `main` (which now includes the Ghidra 12.1.3 template fix and the supported-versions matrix cleanup). Follows the pattern of #343 and supersedes the earlier combined PR #352 (which was cut before #354 and before the 12.1.3 template fix landed on main).

Includes:
- #344 `io.modelcontextprotocol.sdk:mcp-bom` 2.0.0 → 2.0.1
- #345 `com.fasterxml.jackson.dataformat:jackson-dataformat-yaml` 2.22.1 → 2.22.2 (resolutionStrategy `force`)
- #346 `com.fasterxml.jackson.core:jackson-databind` 2.22.1 → 2.22.2 (both `force` and `implementation`)
- #347 `com.fasterxml.jackson.core:jackson-core` 2.22.1 → 2.22.2 (both `force` and `implementation`)
- #348 `gradle/actions/setup-gradle` v6.2.0 → v6.3.0 (workflow files)
- #351 `actions/setup-java` v5 → v6 (workflow files)
- #354 `antoniovazquezblanco/setup-ghidra` v2.1.4 → v2.1.6 (workflow files; picks the newest bump, superseding v2.1.5 from #352)

Diff scope: `build.gradle` + four `.github/workflows/*.yml` files. No source changes.

## Test plan

- [x] Python unit tests (`uv run pytest -m unit`) — 21/21 pass locally
- [ ] `gradle test` — Java unit tests (CI)
- [ ] `gradle integrationTest` — Java integration tests (CI, `Test on Ghidra …` matrix)
- [ ] `uv run pytest` — Python unit + integration + e2e (CI, `Test Headless Mode 🤖`)

The "Ghidra latest" cell that failed on #352 is expected to pass here — the upstream `revaExporter` fix and matrix cleanup for 12.1.3 landed on main in `3cb3e65` / `58912a1`, and the standalone setup-ghidra v2.1.6 bump (#354) is already green on that latest main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ZLvPMro1AK2zPni1LVzfh

---
_Generated by [Claude Code](https://claude.ai/code/session_018ZLvPMro1AK2zPni1LVzfh)_